### PR TITLE
refact(jivavolume): add targetpath

### DIFF
--- a/pkg/apis/openebs/v1alpha1/jivavolume_types.go
+++ b/pkg/apis/openebs/v1alpha1/jivavolume_types.go
@@ -28,9 +28,10 @@ type ISCSISpec struct {
 }
 
 type MountInfo struct {
-	Path       string `json:"mountPath"`
-	FSType     string `json:"fsType"`
-	DevicePath string `json:"devicePath"`
+	StagingPath string `json:"stagingPath"`
+	TargetPath  string `json:"targetPath"`
+	FSType      string `json:"fsType"`
+	DevicePath  string `json:"devicePath"`
 }
 
 // JivaVolumeSpec defines the desired state of JivaVolume


### PR DESCRIPTION
This commit adds target path info in jivavolume CR, targetPath is provided by
K8s in NodePublishVolume rpc call. This info will be helpful in remounting
the volume.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>