### PR TITLE
feat(policy): add support for target and replica tuneables 

### DIFF
--- a/pkg/apis/openebs/v1alpha1/jivavolumepolicy_types.go
+++ b/pkg/apis/openebs/v1alpha1/jivavolumepolicy_types.go
@@ -33,6 +33,11 @@ type JivaVolumePolicySpec struct {
 	EnableBufio bool `json:"enableBufio"`
 	// AutoScaling ...
 	AutoScaling bool `json:"autoScaling"`
+	// ServiceAccountName can be provided to enable PSP
+	ServiceAccountName string `json:"serviceAccountName"`
+	// PriorityClassName if specified applies to the pod
+	// If left empty, no priority class is applied.
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 	// TargetSpec represents configuration related to jiva target and its resources
 	Target TargetSpec `json:"target"`
 	// ReplicaSpec represents configuration related to replicas resources
@@ -78,10 +83,6 @@ type PodTemplateResources struct {
 	// NodeSelector is the labels that will be used to select
 	// a node for pod scheduleing
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
-
-	// PriorityClassName if specified applies to the pod
-	// If left empty, no priority class is applied.
-	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 // JivaVolumePolicyStatus is for handling status of JivaVolumePolicy

--- a/pkg/controller/jivavolume/jivavolume_controller.go
+++ b/pkg/controller/jivavolume/jivavolume_controller.go
@@ -272,48 +272,66 @@ func createControllerDeployment(r *ReconcileJivaVolume, cr *jv.JivaVolume,
 		WithStrategyType(appsv1.RecreateDeploymentStrategyType).
 		WithSelectorMatchLabelsNew(defaultControllerLabels(cr.Spec.PV)).
 		WithPodTemplateSpecBuilder(
-			pts.NewBuilder().
-				WithLabels(defaultControllerLabels(cr.Spec.PV)).
-				WithAnnotations(defaultAnnotations()).
-				WithContainerBuilders(
-					container.NewBuilder().
-						WithName("jiva-controller").
-						WithImage(getImage("OPENEBS_IO_JIVA_CONTROLLER_IMAGE",
-							"jiva-controller")).
-						WithPortsNew(defaultControllerPorts()).
-						WithCommandNew([]string{
-							"launch",
-						}).
-						WithArgumentsNew([]string{
-							"controller",
-							"--frontend",
-							"gotgt",
-							"--clusterIP",
-							cr.Spec.ISCSISpec.TargetIP,
-							cr.Name,
-						}).
-						WithEnvsNew([]corev1.EnvVar{
-							{
-								Name:  "REPLICATION_FACTOR",
-								Value: strconv.Itoa(cr.Spec.Policy.Target.ReplicationFactor),
+			func() *pts.Builder {
+				ptsBuilder := pts.NewBuilder().
+					WithLabels(defaultControllerLabels(cr.Spec.PV)).
+					WithAnnotations(defaultAnnotations()).
+					WithTolerations(cr.Spec.Policy.Target.Tolerations...).
+					WithContainerBuilders(
+						container.NewBuilder().
+							WithName("jiva-controller").
+							WithImage(getImage("OPENEBS_IO_JIVA_CONTROLLER_IMAGE",
+								"jiva-controller")).
+							WithPortsNew(defaultControllerPorts()).
+							WithCommandNew([]string{
+								"launch",
+							}).
+							WithArgumentsNew([]string{
+								"controller",
+								"--frontend",
+								"gotgt",
+								"--clusterIP",
+								cr.Spec.ISCSISpec.TargetIP,
+								cr.Name,
+							}).
+							WithEnvsNew([]corev1.EnvVar{
+								{
+									Name:  "REPLICATION_FACTOR",
+									Value: strconv.Itoa(cr.Spec.Policy.Target.ReplicationFactor),
+								},
+							}).
+							WithResources(cr.Spec.Policy.Target.Resources).
+							WithImagePullPolicy(corev1.PullIfNotPresent),
+					)
+				if cr.Spec.Policy.Target.Monitor {
+					ptsBuilder = ptsBuilder.WithContainerBuilders(
+						container.NewBuilder().
+							WithImage(getImage("OPENEBS_IO_MAYA_EXPORTER_IMAGE",
+								"exporter")).
+							WithImagePullPolicy(corev1.PullIfNotPresent).
+							WithName("maya-volume-exporter").
+							WithCommandNew([]string{"maya-exporter"}).
+							WithPortsNew([]corev1.ContainerPort{
+								{
+									ContainerPort: 9500,
+									Protocol:      "TCP",
+								},
 							},
-						}).
-						WithResources(cr.Spec.Policy.Target.Resources).
-						WithImagePullPolicy(corev1.PullIfNotPresent),
-					container.NewBuilder().
-						WithImage(getImage("OPENEBS_IO_MAYA_EXPORTER_IMAGE",
-							"exporter")).
-						WithName("maya-volume-exporter").
-						WithCommandNew([]string{"maya-exporter"}).
-						WithPortsNew([]corev1.ContainerPort{
-							{
-								ContainerPort: 9500,
-								Protocol:      "TCP",
-							},
-						},
-						),
-				).
-				WithTolerations(cr.Spec.Policy.Target.Tolerations...),
+							).
+							WithResources(cr.Spec.Policy.Target.AuxResources),
+					)
+				}
+				if len(cr.Spec.Policy.ServiceAccountName) != 0 {
+					ptsBuilder = ptsBuilder.WithServiceAccountName(cr.Spec.Policy.ServiceAccountName)
+				}
+				if len(cr.Spec.Policy.PriorityClassName) != 0 {
+					ptsBuilder = ptsBuilder.WithPriorityClassName(cr.Spec.Policy.PriorityClassName)
+				}
+				if cr.Spec.Policy.Target.NodeSelector != nil {
+					ptsBuilder = ptsBuilder.WithNodeSelector(cr.Spec.Policy.Target.NodeSelector)
+				}
+				return ptsBuilder
+			}(),
 		).Build()
 
 	if err != nil {
@@ -469,48 +487,60 @@ func createReplicaStatefulSet(r *ReconcileJivaVolume, cr *jv.JivaVolume,
 		WithReplicas(&replicaCount).
 		WithSelectorMatchLabels(defaultReplicaLabels(cr.Spec.PV)).
 		WithPodTemplateSpecBuilder(
-			pts.NewBuilder().
-				WithLabels(defaultReplicaLabels(cr.Spec.PV)).
-				WithAffinity(&corev1.Affinity{
-					PodAntiAffinity: &corev1.PodAntiAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: defaultReplicaLabels(cr.Spec.PV),
+			func() *pts.Builder {
+				ptsBuilder := pts.NewBuilder().
+					WithLabels(defaultReplicaLabels(cr.Spec.PV)).
+					WithAffinity(&corev1.Affinity{
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: defaultReplicaLabels(cr.Spec.PV),
+									},
+									TopologyKey: "kubernetes.io/hostname",
 								},
-								TopologyKey: "kubernetes.io/hostname",
 							},
 						},
-					},
-				}).
-				WithContainerBuilders(
-					container.NewBuilder().
-						WithName("jiva-replica").
-						WithImage(getImage("OPENEBS_IO_JIVA_REPLICA_IMAGE",
-							"jiva-replica")).
-						WithPortsNew(defaultReplicaPorts()).
-						WithCommandNew([]string{
-							"launch",
-						}).
-						WithArgumentsNew([]string{
-							"replica",
-							"--frontendIP",
-							fmt.Sprintf(svcNameFormat, cr.Name, cr.Namespace),
-							"--size",
-							fmt.Sprint(capacity),
-							"openebs",
-						}).
-						WithImagePullPolicy(corev1.PullIfNotPresent).
-						WithPrivilegedSecurityContext(&prev).
-						WithResources(cr.Spec.Policy.Replica.Resources).
-						WithVolumeMountsNew([]corev1.VolumeMount{
-							{
-								Name:      "openebs",
-								MountPath: "/openebs",
-							},
-						}),
-				).
-				WithTolerations(cr.Spec.Policy.Replica.Tolerations...),
+					}).
+					WithContainerBuilders(
+						container.NewBuilder().
+							WithName("jiva-replica").
+							WithImage(getImage("OPENEBS_IO_JIVA_REPLICA_IMAGE",
+								"jiva-replica")).
+							WithPortsNew(defaultReplicaPorts()).
+							WithCommandNew([]string{
+								"launch",
+							}).
+							WithArgumentsNew([]string{
+								"replica",
+								"--frontendIP",
+								fmt.Sprintf(svcNameFormat, cr.Name, cr.Namespace),
+								"--size",
+								fmt.Sprint(capacity),
+								"openebs",
+							}).
+							WithImagePullPolicy(corev1.PullIfNotPresent).
+							WithPrivilegedSecurityContext(&prev).
+							WithResources(cr.Spec.Policy.Replica.Resources).
+							WithVolumeMountsNew([]corev1.VolumeMount{
+								{
+									Name:      "openebs",
+									MountPath: "/openebs",
+								},
+							}),
+					).
+					WithTolerations(cr.Spec.Policy.Replica.Tolerations...)
+				if len(cr.Spec.Policy.ServiceAccountName) != 0 {
+					ptsBuilder = ptsBuilder.WithServiceAccountName(cr.Spec.Policy.ServiceAccountName)
+				}
+				if len(cr.Spec.Policy.PriorityClassName) != 0 {
+					ptsBuilder = ptsBuilder.WithPriorityClassName(cr.Spec.Policy.PriorityClassName)
+				}
+				if cr.Spec.Policy.Target.NodeSelector != nil {
+					ptsBuilder = ptsBuilder.WithNodeSelector(cr.Spec.Policy.Replica.NodeSelector)
+				}
+				return ptsBuilder
+			}(),
 		).
 		WithPVC(
 			pvc.NewBuilder().
@@ -697,6 +727,16 @@ func getDefaultPolicySpec() jv.JivaVolumePolicySpec {
 					},
 				},
 			},
+			AuxResources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("0"),
+					corev1.ResourceMemory: resource.MustParse("0"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("0"),
+					corev1.ResourceMemory: resource.MustParse("0"),
+				},
+			},
 			ReplicationFactor: defaultReplicationFactor,
 		},
 		Replica: jv.ReplicaSpec{
@@ -735,6 +775,12 @@ func defaultTargetRes(policy *jv.JivaVolumePolicySpec, defaultPolicy jv.JivaVolu
 	}
 }
 
+func defaultTargetAuxRes(policy *jv.JivaVolumePolicySpec, defaultPolicy jv.JivaVolumePolicySpec) {
+	if policy.Target.AuxResources == nil {
+		policy.Target.AuxResources = defaultPolicy.Target.AuxResources
+	}
+}
+
 func defaultReplicaRes(policy *jv.JivaVolumePolicySpec, defaultPolicy jv.JivaVolumePolicySpec) {
 	if policy.Replica.Resources == nil {
 		policy.Replica.Resources = defaultPolicy.Replica.Resources
@@ -756,6 +802,7 @@ func validatePolicySpec(policy *jv.JivaVolumePolicySpec) {
 	optFuncs := []policyOptFuncs{
 		defaultRF, defaultSC, defaultTargetRes, defaultReplicaRes,
 		defaultTargetTolerations, defaultReplicaTolerations,
+		defaultTargetAuxRes,
 	}
 	for _, o := range optFuncs {
 		o(policy, defaultPolicy)

--- a/pkg/controller/jivavolume/jivavolume_controller.go
+++ b/pkg/controller/jivavolume/jivavolume_controller.go
@@ -627,7 +627,7 @@ func updateJivaVolumeWithServiceInfo(r *ReconcileJivaVolume, cr *jv.JivaVolume, 
 func getBaseReplicaTolerations() []corev1.Toleration {
 	return []corev1.Toleration{
 		corev1.Toleration{
-			Key:      "node.alpha.kubernetes.io/notReady",
+			Key:      "node.kubernetes.io/notReady",
 			Effect:   corev1.TaintEffectNoExecute,
 			Operator: corev1.TolerationOpExists,
 		},
@@ -637,7 +637,7 @@ func getBaseReplicaTolerations() []corev1.Toleration {
 			Operator: corev1.TolerationOpExists,
 		},
 		corev1.Toleration{
-			Key:      "node.alpha.kubernetes.io/unreachable",
+			Key:      "node.kubernetes.io/unreachable",
 			Effect:   corev1.TaintEffectNoExecute,
 			Operator: corev1.TolerationOpExists,
 		},
@@ -683,13 +683,13 @@ func getBaseTargetTolerations() []corev1.Toleration {
 	var zero int64
 	return []corev1.Toleration{
 		corev1.Toleration{
-			Key:               "node.alpha.kubernetes.io/notReady",
+			Key:               "node.kubernetes.io/notReady",
 			Effect:            corev1.TaintEffectNoExecute,
 			Operator:          corev1.TolerationOpExists,
 			TolerationSeconds: &zero,
 		},
 		corev1.Toleration{
-			Key:               "node.alpha.kubernetes.io/unreachable",
+			Key:               "node.kubernetes.io/unreachable",
 			Effect:            corev1.TaintEffectNoExecute,
 			Operator:          corev1.TolerationOpExists,
 			TolerationSeconds: &zero,

--- a/pkg/controller/jivavolume/jivavolume_controller.go
+++ b/pkg/controller/jivavolume/jivavolume_controller.go
@@ -652,11 +652,6 @@ func getBaseReplicaTolerations() []corev1.Toleration {
 			Operator: corev1.TolerationOpExists,
 		},
 		corev1.Toleration{
-			Key:      "node.kubernetes.io/unreachable",
-			Effect:   corev1.TaintEffectNoExecute,
-			Operator: corev1.TolerationOpExists,
-		},
-		corev1.Toleration{
 			Key:      "node.kubernetes.io/out-of-disk",
 			Effect:   corev1.TaintEffectNoExecute,
 			Operator: corev1.TolerationOpExists,
@@ -696,12 +691,6 @@ func getBaseTargetTolerations() []corev1.Toleration {
 		},
 		corev1.Toleration{
 			Key:               "node.kubernetes.io/not-ready",
-			Effect:            corev1.TaintEffectNoExecute,
-			Operator:          corev1.TolerationOpExists,
-			TolerationSeconds: &zero,
-		},
-		corev1.Toleration{
-			Key:               "node.kubernetes.io/unreachable",
 			Effect:            corev1.TaintEffectNoExecute,
 			Operator:          corev1.TolerationOpExists,
 			TolerationSeconds: &zero,

--- a/pkg/kubernetes/podtemplatespec/podtemplatespec.go
+++ b/pkg/kubernetes/podtemplatespec/podtemplatespec.go
@@ -209,8 +209,8 @@ func (b *Builder) WithNodeSelectorNew(nodeselectors map[string]string) *Builder 
 }
 
 // WithServiceAccountName sets the ServiceAccountnNme field of podtemplatespec
-func (b *Builder) WithServiceAccountName(serviceAccountnNme string) *Builder {
-	if len(serviceAccountnNme) == 0 {
+func (b *Builder) WithServiceAccountName(serviceAccountName string) *Builder {
+	if len(serviceAccountName) == 0 {
 		b.errs = append(
 			b.errs,
 			errors.New(
@@ -220,7 +220,23 @@ func (b *Builder) WithServiceAccountName(serviceAccountnNme string) *Builder {
 		return b
 	}
 
-	b.podtemplatespec.Object.Spec.ServiceAccountName = serviceAccountnNme
+	b.podtemplatespec.Object.Spec.ServiceAccountName = serviceAccountName
+	return b
+}
+
+// WithPriorityClassName sets the ServiceAccountnNme field of podtemplatespec
+func (b *Builder) WithPriorityClassName(priorityClassName string) *Builder {
+	if len(priorityClassName) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build podtemplatespec object: missing priorityclassname",
+			),
+		)
+		return b
+	}
+
+	b.podtemplatespec.Object.Spec.PriorityClassName = priorityClassName
 	return b
 }
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR adds implementation for tuneable of controller and replica pods:
- monitor
- auxResources
- tolerations 
- serviceAccountName
- priorityClassName
- NodeSelector
