### PR TITLE
chore(build): trigger downstream repo release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,14 @@ script:
   # If this build is running due to travis release tag, and
   # this job indicates to push the release downstream, then
   # go ahead and tag the dependent repo.
+  #
+  # $TRAVIS_BRANCH contains the same value as $TRAVIS_TAG.
+  # Example: 1.9.0-RC1 tag and 1.9.0-RC1 branch. 
+  # OpenEBS release are done from branches named as v1.9.x. 
+  # Convert the TRAVIS_TAG to the corresponding release branch.
   - if [ ! -z $TRAVIS_TAG ] && [ $RELEASE_TAG_DOWNSTREAM = 1 ] && [ "$TRAVIS_REPO_SLUG" == "openebs/jiva-operator" ]; then
-      ./build/git-release "openebs/jiva-csi" "$TRAVIS_TAG" "$TRAVIS_BRANCH" || travis_terminate 1;
+      REL_BRANCH=$(echo v$(echo "$TRAVIS_TAG" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x) ;
+      ./build/git-release "openebs/jiva-csi" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
     fi
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: go
+
 dist: xenial
+
 sudo: required
+
 install: true
+
 services:
   - docker
+
 go:
   - 1.13.x
+
 env:
   global:
     - GOARCH=$(go env GOARCH)
@@ -16,6 +22,13 @@ env:
     - MINIKUBE_HOME=$HOME
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
+
+jobs:
+  include:
+    - os: linux
+      arch: amd64
+      env:
+        - RELEASE_TAG_DOWNSTREAM=1
 addons:
   apt:
     update: true
@@ -38,10 +51,16 @@ script:
   # kube-addon-manager is responsible for managing other kubernetes components, such as kube-dns, dashboard, storage-provisioner..
   #- JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-addon-manager to be available"; kubectl get pods --all-namespaces; done
   - make image
-  #- ./ci/travis-ci.sh
-after_success:
   - make push
+  #- ./ci/travis-ci.sh
+  # If this build is running due to travis release tag, and
+  # this job indicates to push the release downstream, then
+  # go ahead and tag the dependent repo.
+  - if [ ! -z $TRAVIS_TAG ] && [ $RELEASE_TAG_DOWNSTREAM = 1 ] && [ "$TRAVIS_REPO_SLUG" == "openebs/jiva-operator" ]; then
+      ./build/git-release "openebs/jiva-csi" "$TRAVIS_TAG" "$TRAVIS_BRANCH" || travis_terminate 1;
+    fi
 notifications:
   email:
     recipients:
       - kiran.mova@mayadata.io
+      - utkarsh.tripathi@mayadata.io

--- a/build/git-release
+++ b/build/git-release
@@ -1,0 +1,92 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne 3 ]; then
+    echo "Error: Unable to create a new release. Missing required input."
+    echo "Usage: $0 <github org/repo> <tag-name> <branch-name>"
+    echo "Example: $0 kmova/bootstrap v1.0.0 master"
+    exit 1
+fi
+
+C_GIT_URL=$(echo "https://api.github.com/repos/$1/releases")
+C_GIT_TAG_NAME=$2
+C_GIT_TAG_BRANCH=$3
+
+if [ -z ${GIT_NAME} ];
+then
+  echo "Error: Environment variable GIT_NAME not found. Please set it to proceed.";
+  echo "GIT_NAME should be a valid GitHub username.";
+  exit 1
+fi
+
+if [ -z ${GIT_TOKEN} ];
+then
+  echo "Error: Environment variable GIT_TOKEN not found. Please set it to proceed.";
+  echo "GIT_TOKEN should be a valid GitHub token associated with GitHub username.";
+  echo "GIT_TOKEN should be configured with required permissions to create new release.";
+  exit 1
+fi
+
+RELEASE_CREATE_JSON=$(echo \
+{ \
+ \"tag_name\":\"${C_GIT_TAG_NAME}\", \
+ \"target_commitish\":\"${C_GIT_TAG_BRANCH}\", \
+ \"name\":\"${C_GIT_TAG_NAME}\", \
+ \"body\":\"Release created via $0\", \
+ \"draft\":false, \
+ \"prerelease\":false \
+} \
+)
+
+#delete the temporary response file that might 
+#have been left around by previous run of the command
+#using a fixed name means that this script 
+#is not thread safe. only one execution is permitted 
+#at a time.
+TEMP_RESP_FILE=temp-curl-response.txt
+rm -rf ${TEMP_RESP_FILE}
+
+response_code=$(curl -u ${GIT_NAME}:${GIT_TOKEN} \
+ -w "%{http_code}" \
+ --silent \
+ --output ${TEMP_RESP_FILE} \
+ --url ${C_GIT_URL} \
+ --request POST --header 'content-type: application/json' \
+ --data "$RELEASE_CREATE_JSON")
+
+#When embedding this script in other scripts like travis, 
+#success responses like 200 can mean error. rc_code maps
+#the responses to either success (0) or error (1)
+rc_code=0
+
+#Github returns 201 Created on successfully creating a new release
+#201 means the request has been fulfilled and has resulted in one 
+#or more new resources being created.
+if [ $response_code != "201" ]; then
+    echo "Error: Unable to create release. See below response for more details"
+    #The GitHub error response is pretty well formatted.
+    #Printing the body gives all the details to fix the errors
+    #Sample response when the branch already exists looks like this:
+    #{
+    #  "message": "Validation Failed",
+    #  "errors": [
+    #    {
+    #      "resource": "Release",
+    #      "code": "already_exists",
+    #      "field": "tag_name"
+    #    }
+    #  ],
+    #  "documentation_url": "https://developer.github.com/v3/repos/releases/#create-a-release"
+    #}
+    rc_code=1
+else
+    #Note. In case of success, lots of details of returned, but just 
+    #knowing that creation worked is all that matters now.
+    echo "Successfully tagged $1 with release tag ${C_GIT_TAG_NAME} on branch ${C_GIT_TAG_BRANCH}"
+fi
+cat ${TEMP_RESP_FILE}
+
+#delete the temporary response file
+rm -rf ${TEMP_RESP_FILE}
+
+exit ${rc_code}


### PR DESCRIPTION
Jiva Control Plane code is split across multiple repos.

For releasing jiva control plane code, multiple repo's need
to be tagged in a certain order.

This fix will help to trigger the release
on the downstream repo. In this case, after
releasing openebs/jiva-operator, the following repos should be
tagged:
 - openebs/jiva-csi

Note: Due to multiple jobs running in travis,
the release on the downstream should be done
only after the longest job that pushes the
containers is completed. This is manually
configured via ENV variable RELEASE_DOWNSTREAM.

Signed-off-by: kmova <kiran.mova@mayadata.io>