### PR TITLE
refactor(travis): fixing travis for tagging downstream repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,11 +58,31 @@ script:
   # go ahead and tag the dependent repo.
   #
   # $TRAVIS_BRANCH contains the same value as $TRAVIS_TAG.
-  # Example: 1.9.0-RC1 tag and 1.9.0-RC1 branch. 
-  # OpenEBS release are done from branches named as v1.9.x. 
+  # Example: TRAVIS_TAG and TRAVIS_BRANCH will have v1.9.0-RC1,
+  # when github release tag is v1.9.0-RC1
+  #
+  # OpenEBS release are triggered from release branches that are named
+  # as v1.9.x or v1.9.x-hotfix or v1.9.x-custom
+  #
+  # The tag to release branch conversion should be handled as follows:
+  # v1.9.0-RC1 => should be v1.9.x
+  # v1.9.0-hotfixid => should be v1.9.x-hotfixid
+  # v1.9.0 => should be v1.9.x
+  # v1.9.1 => should be v1.9.x
+  # v1.9.0-custom-RC1 => should be v1.9.x-custom
+  # v1.9.0-custom => should be v1.9.x-custom
+  # v1.9.1-custom => should be v1.9.x-custom
   # Convert the TRAVIS_TAG to the corresponding release branch.
   - if [ ! -z $TRAVIS_TAG ] && [ $RELEASE_TAG_DOWNSTREAM = 1 ] && [ "$TRAVIS_REPO_SLUG" == "openebs/jiva-operator" ]; then
-      REL_BRANCH=$(echo v$(echo "$TRAVIS_TAG" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x) ;
+      TAG_SUFFIX=$(echo "$TRAVIS_TAG" | cut -d'-' -f2);
+      if [ "$TAG_SUFFIX" == "$TRAVIS_TAG" ] || [[ $TAG_SUFFIX =~ ^RC ]]; then
+        REL_SUFFIX="";
+      else
+        REL_SUFFIX="-$TAG_SUFFIX";
+      fi;
+
+      REL_BRANCH=$(echo $(echo "$TRAVIS_TAG" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x$REL_SUFFIX);
+
       ./build/git-release "openebs/jiva-csi" "$TRAVIS_TAG" "$REL_BRANCH" || travis_terminate 1;
     fi
 notifications:


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
Earlier We were tagging release with semantic version 1.x.x, which is changed to v1.x.x and there are cases where tag can be on custom release branches, like v1.9.x-hotfix or v1.9.x-custom, apart from regular release branch (v1.9.x).

**What this PR does?**:
This PR fixes the tagging for downstream repo with new semver(like v1.9.1) and also translate the given tag to the corresponding release branch with custom suffixes.

Using the new logic, some examples of tag to branch mappings are:

v1.9.0-RC1 => v1.9.x
v1.9.0-hotfixid => v1.9.x-hotfixid
v1.9.0 => v1.9.x
v1.9.1 => v1.9.x
v1.9.0-custom-RC1 => v1.9.x-custom
v1.9.0-custom => v1.9.x-custom
v1.9.1-custom => v1.9.x-custom

**Does this PR require any upgrade changes?**:
NA

**If the changes in this PR are manually verified, list down the scenarios covered and commands you used for testing with logs:**
Manually verified the script changes using a test script as follows:

```
#!/bin/bash
set -e
starts_with() {
	REL_SUFFIX=""
	TRAVIS_TAG=$1

        TAG_SUFFIX=$(echo "$TRAVIS_TAG" | cut -d'-' -f2);
        if [ "$TAG_SUFFIX" == "$TRAVIS_TAG" ] || [[ $TAG_SUFFIX =~ ^RC ]]; then 
          REL_SUFFIX="";
        else
          REL_SUFFIX="-$TAG_SUFFIX";
        fi;
        REL_BRANCH=$(echo $(echo "$TRAVIS_TAG" | cut -d'-' -f1 | rev | cut -d'.' -f2- | rev).x$REL_SUFFIX) ;
	echo "target_repo" "$TRAVIS_TAG" "${REL_BRANCH}"
} 
starts_with "v1.10.0-RC1"
starts_with "v1.10.0"
starts_with "v1.10.1-RC1"
starts_with "v1.10.1"
starts_with "v1.10.0-custom-RC1"
starts_with "v1.10.0-custom"
starts_with "v1.10.1-custom-RC1"
starts_with "v1.10.1-custom"
starts_with "v1.10.1-hostfixid-RC1"
```

Output:

```
target_repo v1.10.0-RC1 v1.10.x
target_repo v1.10.0 v1.10.x
target_repo v1.10.1-RC1 v1.10.x
target_repo v1.10.1 v1.10.x
target_repo v1.10.0-custom-RC1 v1.10.x-custom
target_repo v1.10.0-custom v1.10.x-custom
target_repo v1.10.1-custom-RC1 v1.10.x-custom
target_repo v1.10.1-custom v1.10.x-custom
target_repo v1.10.1-hostfixid-RC1 v1.10.x-hostfixid
```
**Any additional information for your reviewer?**:
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

Signed-off-by: mayank <mayank.patel@mayadata.io>