### PR TITLE
feat(policy): add support for target affinity for controller

### DIFF
--- a/pkg/controller/jivavolume/jivavolume_controller.go
+++ b/pkg/controller/jivavolume/jivavolume_controller.go
@@ -363,6 +363,9 @@ func createControllerDeployment(r *ReconcileJivaVolume, cr *jv.JivaVolume,
 				if cr.Spec.Policy.Target.NodeSelector != nil {
 					ptsBuilder = ptsBuilder.WithNodeSelector(cr.Spec.Policy.Target.NodeSelector)
 				}
+				if cr.Spec.Policy.Target.Affinity != nil {
+					ptsBuilder = ptsBuilder.WithAffinity(cr.Spec.Policy.Target.Affinity)
+				}
 				return ptsBuilder
 			}(),
 		).Build()


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR adds support for target affinity via policy where the controller pod and be scheduled according to the target affinity mentioned in the policy. For the replica, it has anti-affinity by default and affinity can be achieved via localpv storageclass https://docs.openebs.io/docs/next/uglocalpv-hostpath.html#create-storageclass