### PR TITLE
fix(reconcile): removed defer to enable reconcile on failed volumes

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3155,7 +3155,94 @@ spec:
         type: object
     served: true
     storage: true
-
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jiva-operator
+  namespace: openebs
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: jiva-operator
+  namespace: openebs
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - jiva-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
+  - openebs.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jiva-operator
+  namespace: openebs
+subjects:
+- kind: ServiceAccount
+  name: jiva-operator
+roleRef:
+  kind: Role
+  name: jiva-operator
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/pkg/controller/jivavolume/jivavolume_controller.go
+++ b/pkg/controller/jivavolume/jivavolume_controller.go
@@ -238,15 +238,13 @@ func (r *ReconcileJivaVolume) shouldReconcile(cr *jv.JivaVolume) (bool, error) {
 // 2. Create controller deploy
 // 3. Create replica statefulset
 func (r *ReconcileJivaVolume) bootstrapJiva(cr *jv.JivaVolume, reqLog logr.Logger) (err error) {
-	defer r.finally(err, cr, reqLog)
-
 	for _, f := range installFuncs {
 		if err = f(r, cr, reqLog); err != nil {
-			return err
+			break
 		}
 	}
-
-	return nil
+	r.finally(err, cr, reqLog)
+	return err
 }
 
 // TODO: add logic to create disruption budget for replicas


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR removes the defer call and adds a break statement to enable reconcile on failed volumes.
It also adds the rbac which were removed accidentally in a previous PR #34 