### PR TITLE
fix(operator): update role to use statefulset ownerreference permission

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3204,6 +3204,7 @@ rules:
   - jiva-operator
   resources:
   - deployments/finalizers
+  - statefulsets/finalizers
   verbs:
   - update
 - apiGroups:


### PR DESCRIPTION
This PR contains changes required in openshift based cluster which needs these permission to
be enabled for jiva-operator role to set the ownerreference in stateful set pods.

Note: Required in OpenShift based k8s clusters

**Error:**

```sh
Warning  FailedCreate  4m6s (x12 over 4m16s)   statefulset-controller  create Pod pvc-716d9b78-02e3-4964-a529-b37ef69e13db-jiva-rep-0 in StatefulSet pvc-716d9b78-02e3-4964-a529-b37ef69e13db-jiva-rep failed error: failed to create PVC openebs-pvc-716d9b78-02e3-4964-a529-b37ef69e13db-jiva-rep-0: persistentvolumeclaims "openebs-pvc-716d9b78-02e3-4964-a529-b37ef69e13db-jiva-rep-0" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
  Warning  FailedCreate  3m56s (x13 over 4m16s)  statefulset-controller  create Claim openebs-pvc-716d9b78-02e3-4964-a529-b37ef69e13db-jiva-rep-0 for Pod pvc-716d9b78-02e3-4964-a529-b37ef69e13db-jiva-rep-0 in StatefulSet pvc-716d9b78-02e3-4964-a529-b37ef69e13db-jiva-rep failed error: persistentvolumeclaims "openebs-pvc-716d9b78-02e3-4964-a529-b37ef69e13db-jiva-rep-0" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```
<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->

Signed-off-by: Payes Anand <payes.anand@mayadata.io>