### PR TITLE
feat(operator): add ability to scale up replicas via CR

### DIFF
--- a/deploy/crds/openebs.io_jivavolumes.yaml
+++ b/deploy/crds/openebs.io_jivavolumes.yaml
@@ -55,6 +55,8 @@ spec:
                 type: string
               capacity:
                 type: string
+              desiredReplicationFactor:
+                type: integer
               iscsiSpec:
                 nullable: true
                 properties:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1560,6 +1560,8 @@ spec:
                 type: string
               capacity:
                 type: string
+              desiredReplicationFactor:
+                type: integer
               iscsiSpec:
                 nullable: true
                 properties:

--- a/pkg/apis/openebs/v1alpha1/jivavolume_types.go
+++ b/pkg/apis/openebs/v1alpha1/jivavolume_types.go
@@ -54,7 +54,8 @@ type JivaVolumeSpec struct {
 	// Policy is the configuration used for creating target
 	// and replica pods during volume provisioning
 	// +nullable
-	Policy JivaVolumePolicySpec `json:"policy,omitempty"`
+	Policy                   JivaVolumePolicySpec `json:"policy,omitempty"`
+	DesiredReplicationFactor int                  `json:"desiredReplicationFactor,omitempty"`
 }
 
 // JivaVolumeStatus defines the observed state of JivaVolume

--- a/pkg/apis/openebs/v1alpha1/jivavolume_types.go
+++ b/pkg/apis/openebs/v1alpha1/jivavolume_types.go
@@ -119,6 +119,10 @@ const (
 	// has failed
 	JivaVolumePhaseFailed JivaVolumePhase = "Failed"
 
+	// JivaVolumePhaseUnkown indicates that the jivavolume status get
+	// failed as controller was not reachable
+	JivaVolumePhaseUnkown JivaVolumePhase = "Unknown"
+
 	// JivaVolumePhaseReady indicates that the jivavolume provisioning
 	// has Created
 	JivaVolumePhaseReady JivaVolumePhase = "Ready"

--- a/pkg/controllers/jivavolume_controller.go
+++ b/pkg/controllers/jivavolume_controller.go
@@ -139,21 +139,45 @@ func (r *JivaVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// depends upon the error. If bootstrap is successful it will set the Phase
 	// to syncing which will be changed to Ready later when volume becomes RW
 	switch instance.Status.Phase {
-	case openebsiov1alpha1.JivaVolumePhaseReady, openebsiov1alpha1.JivaVolumePhaseSyncing:
+	case openebsiov1alpha1.JivaVolumePhaseReady:
+		if isScaleup(instance) {
+			logrus.Info("performing scaleup operation on " + instance.Name)
+			err = r.performScaleup(instance)
+			if err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to scaleup volume %s: %s",
+					instance.Name, err.Error())
+			}
+		}
+	case openebsiov1alpha1.JivaVolumePhaseSyncing:
 		return reconcile.Result{}, r.getAndUpdateVolumeStatus(instance)
 	case openebsiov1alpha1.JivaVolumePhaseDeleting:
 		logrus.Info("start tearing down jiva components", "JivaVolume: ", instance.Name)
 		return reconcile.Result{}, nil
-	case openebsiov1alpha1.JivaVolumePhasePending, openebsiov1alpha1.JivaVolumePhaseFailed:
+	case "", openebsiov1alpha1.JivaVolumePhasePending, openebsiov1alpha1.JivaVolumePhaseFailed:
 		if ok {
 			logrus.Info("start bootstraping jiva components", "JivaVolume: ", instance.Name)
 			return reconcile.Result{}, r.bootstrapJiva(instance)
 		}
 	}
 
-	logrus.Info("start bootstraping jiva components", "JivaVolume: ", instance.Name)
-	return reconcile.Result{}, r.bootstrapJiva(instance)
+	return reconcile.Result{}, nil
+}
 
+func isScaleup(cr *openebsiov1alpha1.JivaVolume) bool {
+	if cr.Spec.DesiredReplicationFactor > cr.Spec.Policy.Target.ReplicationFactor {
+		if cr.Spec.DesiredReplicationFactor-cr.Spec.Policy.Target.ReplicationFactor != 1 {
+			logrus.Errorf("Failed to scaleup, only single replica scaleup is allowed, desired: %v actual: %v",
+				cr.Spec.DesiredReplicationFactor, cr.Spec.Policy.Target.ReplicationFactor)
+			return false
+		}
+		if cr.Spec.Policy.Target.ReplicationFactor != cr.Status.ReplicaCount {
+			logrus.Errorf("Failed to scaleup, replica count: %v in status not equal to replicationfatcor: %v",
+				cr.Spec.DesiredReplicationFactor, cr.Spec.Policy.Target.ReplicationFactor)
+			return false
+		}
+		return true
+	}
+	return false
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -205,6 +229,9 @@ func (r *JivaVolumeReconciler) bootstrapJiva(cr *openebsiov1alpha1.JivaVolume) (
 
 // TODO: add logic to create disruption budget for replicas
 func createReplicaPodDisruptionBudget(r *JivaVolumeReconciler, cr *openebsiov1alpha1.JivaVolume) error {
+	if cr.Spec.Policy.Target.ReplicationFactor < 3 {
+		return nil
+	}
 	min := cr.Spec.Policy.Target.ReplicationFactor
 	pdbObj := &policyv1beta1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
@@ -245,6 +272,53 @@ func createReplicaPodDisruptionBudget(r *JivaVolumeReconciler, cr *openebsiov1al
 		return operr.Wrapf(err, "failed to get the pod disruption budget details: %v", pdbObj.Name)
 	}
 
+	return nil
+}
+
+func (r *JivaVolumeReconciler) performScaleup(cr *openebsiov1alpha1.JivaVolume) error {
+	// update the replica sts with the desired replica count
+	// this will bring a new hostpath pvc on a new node and a
+	// new pod
+	replicaName := cr.Name + "-jiva-rep"
+	replicaSTS := &appsv1.StatefulSet{}
+	err := r.Get(context.TODO(),
+		types.NamespacedName{Name: replicaName, Namespace: cr.Namespace}, replicaSTS)
+	if err != nil {
+		return err
+	}
+	desiredReplicas := int32(cr.Spec.DesiredReplicationFactor)
+	newReplicaSTS := replicaSTS.DeepCopy()
+	newReplicaSTS.Spec.Replicas = &desiredReplicas
+	err = r.Patch(context.TODO(), newReplicaSTS, client.MergeFrom(replicaSTS))
+	if err != nil {
+		return err
+	}
+
+	// update the controller envs to the desired replica count
+	controllerName := cr.Name + "-jiva-ctrl"
+	ctrlDeploy := &appsv1.Deployment{}
+	err = r.Get(context.TODO(),
+		types.NamespacedName{Name: controllerName, Namespace: cr.Namespace}, ctrlDeploy)
+	if err != nil {
+		return err
+	}
+	newCtrlDeploy := ctrlDeploy.DeepCopy()
+	for i, con := range newCtrlDeploy.Spec.Template.Spec.Containers {
+		if con.Name == "jiva-controller" {
+			newCtrlDeploy.Spec.Template.Spec.Containers[i].Env[0].Value = strconv.Itoa(cr.Spec.DesiredReplicationFactor)
+		}
+	}
+	err = r.Patch(context.TODO(), newCtrlDeploy, client.MergeFrom(ctrlDeploy))
+	if err != nil {
+		return err
+	}
+
+	if err := r.getJivaVolume(cr); err != nil {
+		return fmt.Errorf("%s, err: %v", updateErrMsg, err)
+	}
+	cr.Spec.Policy.Target.ReplicationFactor = int(desiredReplicas)
+	cr.Status.Phase = openebsiov1alpha1.JivaVolumePhaseSyncing
+	r.finally(nil, cr)
 	return nil
 }
 
@@ -820,6 +894,7 @@ func populateJivaVolumePolicy(r *JivaVolumeReconciler, cr *openebsiov1alpha1.Jiv
 		validatePolicySpec(&policySpec)
 	}
 	cr.Spec.Policy = policySpec
+	cr.Spec.DesiredReplicationFactor = policySpec.Target.ReplicationFactor
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR adds the following:
 - a spec field named desiredReplicationFactor which will be used to scale up replicas automatically
 - controller implementation for the above
 - updates the CRDs for the above change