### PR TITLE
fix(resize): respond success if volume is already of same size

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -69,7 +69,7 @@ jobs:
   e2e-tests:
     needs: ['unit-tests']
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -329,7 +329,8 @@ func (cs *controller) ControllerExpandVolume(
 	retryCount = 0
 	for retryCount < httpReqRetryCount {
 		httpErr = cli.Post(vol.Data[0].Actions["resize"], input, nil)
-		if httpErr == nil {
+		if httpErr == nil || strings.Contains(httpErr.Error(), "Volume size same as size mentioned") {
+			httpErr = nil
 			break
 		}
 		time.Sleep(httpReqRetryInterval)


### PR DESCRIPTION
If resize is attempted even if the previous resize was successful, jiva throws the following error:
```
Volume size same as size mentioned
```
This PR catches this error and returns success to kubernetes if the volume is already resized.
Signed-off-by: Payes Anand <payes.anand@mayadata.io>