### PR TITLE
fix(build): remove cache env from ci builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -118,8 +118,6 @@ jobs:
           version: v0.5.1
 
       - name: Build Image
-        env:
-          IMG_RESULT: cache
         run: make docker.buildx.csi-driver
 
   jiva-operator:
@@ -141,6 +139,4 @@ jobs:
           version: v0.5.1
 
       - name: Build Image
-        env:
-          IMG_RESULT: cache
         run: make docker.buildx.jiva-operator

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,7 +141,6 @@ jobs:
           IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
         run: |
           make docker.buildx.csi-driver
-          make buildx.push.csi-driver
 
   jiva-operator:
     runs-on: ubuntu-latest
@@ -182,4 +181,3 @@ jobs:
           IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
         run: |
           make docker.buildx.jiva-operator
-          make buildx.push.jiva-operator


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR removes the cache env from the ci builds which was preventing the images from being pushed. It also removes the push command failing due to the push script as the docker buildx automatically pushes the images on release workflow.