### PR TITLE
chore(k8s): updated csi driver version to v1

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: Jiva-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.7.0
+version: 2.7.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.7.0

--- a/deploy/jiva-csi.yaml
+++ b/deploy/jiva-csi.yaml
@@ -8,7 +8,7 @@
 # 2) Check which files are already present in the openebs-csi-plugin container present in csi node pod.
 # 3) Mount the required missing files inside the node-plugin container.
 
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: jiva.csi.openebs.io

--- a/version/util.go
+++ b/version/util.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	validCurrentVersions = map[string]bool{
-		"2.6.0": true, "2.7.0": true,
+		"2.6.0": true, "2.7.0": true, "2.8.0": true,
 	}
 	validDesiredVersion = strings.Split(Version, "-")[0]
 )


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

With k8s v1.22 the v1beta1 for various resources will no longer be supported. This PR updates the csi driver api version to v1.

This PR also bumps the version matrix for v2.8.0