### PR TITLE
fix(controller): fix node selector for replica sts

### DIFF
--- a/pkg/controllers/jivavolume_controller.go
+++ b/pkg/controllers/jivavolume_controller.go
@@ -631,7 +631,7 @@ func createReplicaStatefulSet(r *JivaVolumeReconciler, cr *openebsiov1alpha1.Jiv
 				if len(cr.Spec.Policy.PriorityClassName) != 0 {
 					ptsBuilder = ptsBuilder.WithPriorityClassName(cr.Spec.Policy.PriorityClassName)
 				}
-				if cr.Spec.Policy.Target.NodeSelector != nil {
+				if cr.Spec.Policy.Replica.NodeSelector != nil {
 					ptsBuilder = ptsBuilder.WithNodeSelector(cr.Spec.Policy.Replica.NodeSelector)
 				}
 				return ptsBuilder


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR fixes the jiva volume controller, the node selector for the replica sts was checking for the Target instead of the Replica spec in the policy of the jiva volume CR.