### PR TITLE
chore(github-action): Refine GitHub Actions criteria for builds, pull requests and release, added Build & Push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,6 +122,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG }}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
+
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+
       - name: Set Tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
@@ -131,11 +142,24 @@ jobs:
           fi
           echo "TAG=${CI_TAG}" >> $GITHUB_ENV
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/jiva-csi
+            quay.io/${{ env.IMAGE_ORG }}/jiva-csi
+          tag-latest: false
+          tag-custom-only: true
+          tag-custom: |
+            ${{ env.TAG }}
 
       - name: Print Tag info
         run: |
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${TAG}"
+          echo "${{ steps.docker_meta.outputs.tags }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -154,8 +178,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build and Push Image
-        run: make docker.buildx.csi-driver
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/jiva-csi/jiva-csi.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/jiva-operator
+            DBUILD_SITE_URL=https://openebs.io
+            BRANCH=${{ env.BRANCH }}
 
   jiva-operator:
     runs-on: ubuntu-latest
@@ -164,6 +207,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG }}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
+
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+
       - name: Set Tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
@@ -174,11 +228,23 @@ jobs:
           echo "TAG=${CI_TAG}" >> $GITHUB_ENV
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
 
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/jiva-operator
+            quay.io/${{ env.IMAGE_ORG }}/jiva-operator
+          tag-latest: false
+          tag-custom-only: true
+          tag-custom: |
+            ${{ env.TAG }}
+      
       - name: Print Tag info
         run: |
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${TAG}"
-
+          echo "${{ steps.docker_meta.outputs.tags }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -197,5 +263,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build and Push Image
-        run: make docker.buildx.jiva-operator
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/jiva-operator/jiva-operator.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/jiva-operator
+            DBUILD_SITE_URL=https://openebs.io
+            BRANCH=${{ env.BRANCH }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,15 +15,23 @@
 name: build
 
 on:
+  create:
   push:
+    branches:
+      - 'master'
+      - 'v*'
     paths-ignore:
-    # The line below will be required once docs/ directory is created
-    # - 'docs/**'
-    - 'deploy/helm/**'
-    - 'changelogs/**'
+      - '*.md'
+      - 'changelogs/**'
+      - 'deploy/helm/**'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'MAINTAINERS'
 
 jobs:
   lint:
+    # to ignore builds on release
+    if: ${{ (github.event.ref_type != 'tag') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -39,6 +47,8 @@ jobs:
           exclude: './vendor/*'
 
   unit-tests:
+    # to ignore builds on release
+    if: ${{ (github.event.ref_type != 'tag') }}
     name: unit tests 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,13 @@
 
 name: build
 
-on: ['push']
+on:
+  push:
+    paths-ignore:
+    # The line below will be required once docs/ directory is created
+    # - 'docs/**'
+    - 'deploy/helm/**'
+    - 'changelogs/**'
 
 jobs:
   lint:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,10 @@ name: ci
 on:
   pull_request:
     paths-ignore:
+      # The line below will be required once docs/ directory is created
+      # - 'docs/**'
       - 'deploy/helm/**'
+      - 'changelogs/**'
     branches:
       # on pull requests to master and release branches
       - master

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,15 +16,17 @@ name: ci
 
 on:
   pull_request:
-    paths-ignore:
-      # The line below will be required once docs/ directory is created
-      # - 'docs/**'
-      - 'deploy/helm/**'
-      - 'changelogs/**'
     branches:
       # on pull requests to master and release branches
-      - master
+      - 'master'
       - 'v*'
+    paths-ignore:
+      - '*.md'
+      - 'changelogs/**'
+      - 'deploy/helm/**'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'MAINTAINERS'
 
 jobs:
   lint:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -135,10 +135,15 @@ jobs:
         with:
           version: v0.5.1
 
-      - name: Build Image
-        env:
-          IMG_RESULT: cache
-        run: make docker.buildx.csi-driver
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/jiva-csi/jiva-csi.Dockerfile
+          push: false
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            openebs/jiva-csi:ci
 
   jiva-operator:
     runs-on: ubuntu-latest
@@ -158,7 +163,12 @@ jobs:
         with:
           version: v0.5.1
 
-      - name: Build Image
-        env:
-          IMG_RESULT: cache
-        run: make docker.buildx.jiva-operator
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/jiva-operator/jiva-operator.Dockerfile
+          push: false
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            openebs/jiva-operator:ci

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,9 @@
 name: release
 
 on:
-  create:
+  release:
+    types:
+      - 'created'
     tags:
       - 'v*'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -166,6 +166,7 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build & Push Image
+        uses: docker/build-push-action@v2
         with:
           context: .
           file: ./build/jiva-operator/jiva-operator.Dockerfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,94 +22,22 @@ on:
       - 'v*'
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Shellcheck
-        uses: reviewdog/action-shellcheck@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review
-          path: '.'
-          pattern: '*.sh'
-          exclude: './vendor/*'
-
-  unit-tests:
-    name: unit tests 
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Set up Go 1.14
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.14.7
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - name: verify license
-      run: make license-check
-
-    - name: verify dependencies
-      run: make deps
-
-    - name: verify tests
-      run: make test
-
-  e2e-tests:
-    needs: ['unit-tests']
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        kubernetes: [v1.18.6]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Go 1.14
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.14.7
-
-      - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.3.0
-        with:
-          minikube version: v1.9.2
-          kubernetes version: ${{ matrix.kubernetes }}
-          github token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set tag
-        run: |
-          BRANCH="${GITHUB_REF##*/}"
-          CI_TAG="ci"
-          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
-          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
-
-      - name: Build images locally
-        run: make image.operator image.plugin || exit 1;
-
-      - name: Install tests dependencies
-        run: make bootstrap
-
-      - name: Running tests
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml
-          kubectl apply -f deploy/operator.yaml
-          kubectl apply -f deploy/jiva-csi.yaml
-          ./ci/ci.sh
-          cd ./tests
-          make tests
-
   csi-driver:
     runs-on: ubuntu-latest
-    needs: ['lint', 'unit-tests', 'e2e-tests']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG }}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
+
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
 
       - name: Set Tag
         run: |
@@ -117,8 +45,21 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
 
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/jiva-csi
+            quay.io/${{ env.IMAGE_ORG }}/jiva-csi
+          tag-latest: true
+          tag-semver: |
+            {{version}}
+
       - name: Print Tag info
         run: |
+          echo "${{ steps.docker_meta.outputs.tags }}"
           echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Set up QEMU
@@ -138,18 +79,44 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.csi-driver
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/jiva-csi/jiva-csi.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/jiva-operator
+            DBUILD_SITE_URL=https://openebs.io
+            RELEASE_TAG=${{ env.RELEASE_TAG }}
 
   jiva-operator:
     runs-on: ubuntu-latest
-    needs: ['lint', 'unit-tests', 'e2e-tests']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG }}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
+
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
 
       - name: Set Tag
         run: |
@@ -157,8 +124,21 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
 
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/jiva-operator
+            quay.io/${{ env.IMAGE_ORG }}/jiva-operator
+          tag-latest: true
+          tag-semver: |
+            {{version}}
+
       - name: Print Tag info
         run: |
+          echo "${{ steps.docker_meta.outputs.tags }}"
           echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Set up QEMU
@@ -178,8 +158,23 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.jiva-operator
+        with:
+          context: .
+          file: ./build/jiva-operator/jiva-operator.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/jiva-operator
+            DBUILD_SITE_URL=https://openebs.io
+            RELEASE_TAG=${{ env.RELEASE_TAG }}

--- a/version/util.go
+++ b/version/util.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	validCurrentVersions = map[string]bool{
-		"2.6.0": true, "2.7.0": true, "2.8.0": true,
+		"2.6.0": true, "2.7.0": true, "2.8.0": true, "2.9.0": true,
 	}
 	validDesiredVersion = strings.Split(Version, "-")[0]
 )


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

The build.yml and pull_request.yml workflows will ignore pushes made to `deploy/helm/`, `changelogs/` and 'docs/' directories. all .md files, LICENSE and MAINTAINERS files.

Added criteria to ignore build workflows on release.

Build & Push is performed using Actions and not the makefile directly.