### PR TITLE
fix(helm chart): rename priority class name for CSI plugin (node and controller)

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: Jiva-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.8.0
+version: 2.8.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.8.0

--- a/deploy/helm/charts/templates/_helpers.tpl
+++ b/deploy/helm/charts/templates/_helpers.tpl
@@ -126,3 +126,25 @@ Create labels for jiva csi controller
 {{ include "jiva.csiController.matchLabels" . }}
 {{ include "jiva.csiController.componentLabels" . }}
 {{- end -}}
+
+{{/*
+Create the name of the priority class for csi node plugin
+*/}}
+{{- define "jiva.csiNode.priorityClassName" -}}
+{{- if .Values.csiNode.priorityClass.create }}
+{{- printf "%s-%s" .Release.Name .Values.csiNode.priorityClass.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s" .Values.csiNode.priorityClass.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the priority class for csi controller plugin
+*/}}
+{{- define "jiva.csiController.priorityClassName" -}}
+{{- if .Values.csiController.priorityClass.create }}
+{{- printf "%s-%s" .Release.Name .Values.csiController.priorityClass.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s" .Values.csiController.priorityClass.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/charts/templates/csi-controller.yaml
+++ b/deploy/helm/charts/templates/csi-controller.yaml
@@ -21,7 +21,7 @@ spec:
         {{ toYaml .Values.csiController.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      priorityClassName: openebs-jiva-csi-controller-critical
+      priorityClassName: {{ template "jiva.csiController.priorityClassName" . }}
       serviceAccount: {{ .Values.serviceAccount.csiController.name }}
       containers:
         - name: {{ .Values.csiController.resizer.name }}

--- a/deploy/helm/charts/templates/csi-controller.yaml
+++ b/deploy/helm/charts/templates/csi-controller.yaml
@@ -21,7 +21,7 @@ spec:
         {{ toYaml .Values.csiController.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      priorityClassName: openebs-csi-controller-critical
+      priorityClassName: openebs-jiva-csi-controller-critical
       serviceAccount: {{ .Values.serviceAccount.csiController.name }}
       containers:
         - name: {{ .Values.csiController.resizer.name }}

--- a/deploy/helm/charts/templates/csi-node.yaml
+++ b/deploy/helm/charts/templates/csi-node.yaml
@@ -19,7 +19,7 @@ spec:
         {{ toYaml .Values.csiNode.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      priorityClassName: openebs-csi-node-critical
+      priorityClassName: openebs-jiva-csi-node-critical
       serviceAccount: {{ .Values.serviceAccount.csiNode.name }}
       hostNetwork: true
       containers:

--- a/deploy/helm/charts/templates/csi-node.yaml
+++ b/deploy/helm/charts/templates/csi-node.yaml
@@ -19,7 +19,7 @@ spec:
         {{ toYaml .Values.csiNode.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      priorityClassName: openebs-jiva-csi-node-critical
+      priorityClassName: {{ template "jiva.csiNode.priorityClassName" . }}
       serviceAccount: {{ .Values.serviceAccount.csiNode.name }}
       hostNetwork: true
       containers:

--- a/deploy/helm/charts/templates/priority-class.yaml
+++ b/deploy/helm/charts/templates/priority-class.yaml
@@ -1,15 +1,19 @@
+{{- if .Values.csiController.priorityClass.create }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: openebs-jiva-csi-controller-critical
+  name: {{ template "jiva.csiController.priorityClassName" . }}
 value: 900000000
 globalDefault: false
 description: "This priority class should be used for the OpenEBS CSI driver controller deployment only."
+{{- end }}
 ---
+{{- if .Values.csiNode.priorityClass.create }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: openebs-jiva-csi-node-critical
+  name: {{ template "jiva.csiNode.priorityClassName" . }}
 value: 900001000
 globalDefault: false
 description: "This priority class should be used for the OpenEBS CSI driver node deployment only."
+{{- end }}

--- a/deploy/helm/charts/templates/priority-class.yaml
+++ b/deploy/helm/charts/templates/priority-class.yaml
@@ -1,7 +1,7 @@
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: openebs-csi-controller-critical
+  name: openebs-jiva-csi-controller-critical
 value: 900000000
 globalDefault: false
 description: "This priority class should be used for the OpenEBS CSI driver controller deployment only."
@@ -9,7 +9,7 @@ description: "This priority class should be used for the OpenEBS CSI driver cont
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: openebs-csi-node-critical
+  name: openebs-jiva-csi-node-critical
 value: 900001000
 globalDefault: false
 description: "This priority class should be used for the OpenEBS CSI driver node deployment only."

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -50,6 +50,9 @@ jivaOperator:
 
 
 csiController:
+  priorityClass:
+    create: true
+    name: jiva-csi-controller-critical
   componentName: "openebs-jiva-csi-controller"
   attacher:
     name: "csi-attacher"
@@ -112,6 +115,9 @@ jivaCSIPlugin:
   remount: "true"
 
 csiNode:
+  priorityClass:
+    create: true
+    name: jiva-csi-node-critical
   componentName: "openebs-jiva-csi-node"
   driverRegistrar:
     name: "csi-node-driver-registrar"


### PR DESCRIPTION
Include storage engine name in priority class name to make sure CSI driver of different storage will have different priority class. This will resolve the issue of installing multiple storage engine using helm chart.

What will happen to older priority classes(upgrade scenario)?
=> Older priority classes will be deleted and CSI node and controller driver pod will be restarted with new priority classes.


