### PR TITLE
fix(csi): create jivaVolume CR in the csi controller namespace

### DIFF
--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -19,6 +19,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/openebs/jiva-operator/pkg/apis"
@@ -154,10 +155,8 @@ func (cl *Client) CreateJivaVolume(req *csi.CreateVolumeRequest) (string, error)
 	name := utils.StripName(req.GetName())
 	policyName := req.GetParameters()["policy"]
 	pvcName := req.GetParameters()[pvcNameKey]
-	ns, ok := req.GetParameters()["namespace"]
-	if !ok {
-		ns = defaultNS
-	}
+	ns := os.Getenv("OPENEBS_NAMESPACE")
+
 	if req.GetCapacityRange() == nil {
 		logrus.Warningf("CreateVolume: capacity range is nil, provisioning with default size: {%v (bytes)}", defaultSizeBytes)
 		sizeBytes = defaultSizeBytes


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR addresses the issue : #92 

Earlier jiva was designed to run the volume pods in the application namespace, but we decided to have all openebs related pods in one namespace itself. The jiva-csi controller still was expecting the namespace param from the policy and setting the namespace as default `openebs`. All the envs are already set up correctly on the helm and operator charts.