### PR TITLE
feat(charts): add default policy and storageclass

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: Jiva-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.9.0
+version: 2.9.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.9.0

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -160,6 +160,14 @@ helm upgrade openebs-jiva openebs-jiva/jiva -n openebs \
 | csiNode.livenessprobe.image.repository | string | `"k8scsi/livenessprobe"` |  CSI livenessprobe image repo |
 | csiNode.livenessprobe.image.tag | string | `"v2.2.0"` | CSI livenessprobe image tag |
 | csiNode.livenessprobe.name | string | `"liveness-probe"` |  CSI livenessprobe container name|
+| defaultPolicy.name | string | `"openebs-jiva-default-policy"` | Default jiva volume policy |
+| defaultPolicy.enabled | bool | `true`  | Enable default jiva volume policy |
+| defaultPolicy.replicaSC | string | `"openebs-hostpath"` | StorageClass used for creating the PVC for the replica STS |
+| defaultPolicy.replicas | string | `"3"` | The desired replication factor for the jiva volumes |
+| defaultClass.name | string | `"openebs-jiva-csi-default"` | Default jiva csi StorageClass |
+| defaultClass.enabled | bool | `true`  | Enable default jiva csi StorageClass |
+| defaultClass.reclaimPolicy | string | `"Delete"` | Reclaim Policy for the StorageClass |
+| defaultClass.isDefaultClass | bool | `false` | Make jiva csi StorageClass as the default StorageClass |
 | jivaOperator.annotations | object | `{}` | Jiva operator annotations |
 | jivaOperator.componentName | string | `"jiva-operator"` | Jiva operator component name |
 | jivaOperator.image.pullPolicy | string | `"IfNotPresent"` | Jiva operator image pull policy |

--- a/deploy/helm/charts/templates/default-policy.yaml
+++ b/deploy/helm/charts/templates/default-policy.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.defaultPolicy.enabled }}
+apiVersion: openebs.io/v1alpha1
+kind: JivaVolumePolicy
+metadata:
+  name: {{ .Values.defaultPolicy.name }}
+spec:
+  replicaSC: {{ .Values.defaultPolicy.replicaSC }}
+  enableBufio: false
+  autoScaling: false
+  target:
+    replicationFactor: {{ .Values.defaultPolicy.replicas }}
+{{- end }}

--- a/deploy/helm/charts/templates/default-storageclass.yaml
+++ b/deploy/helm/charts/templates/default-storageclass.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.defaultClass.enabled }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.defaultClass.name }}
+  annotations:
+{{- if .Values.defaultClass.isDefaultClass }}
+    storageclass.kubernetes.io/is-default-class: "true"
+{{- end }}
+provisioner: jiva.csi.openebs.io
+volumeBindingMode: Immediate
+reclaimPolicy: {{ .Values.defaultClass.reclaimPolicy }}
+parameters:
+  cas-type: "jiva"
+  policy: {{ .Values.defaultPolicy.name }}
+{{- end }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -190,3 +190,24 @@ localpv-provisioner:
   # Disable openebs-device deviceClass by default.
   deviceClass:
     enabled: false
+
+defaultClass:
+  # Name of the default default StorageClass
+  name: openebs-jiva-csi-default
+  # If true, enables creation of the openebs-jiva-csi-default StorageClass
+  enabled: true
+  # Available reclaim policies: Delete/Retain, defaults: Delete.
+  reclaimPolicy: Delete
+  # If true, sets the openebs-jiva-csi-default StorageClass as the default StorageClass
+  isDefaultClass: false
+
+defaultPolicy:
+  # Name of the default default JivaVolumePolicy
+  name: openebs-jiva-default-policy
+  # If true, enables creation of the openebs-jiva-default-policy JivaVolumePolicy
+  enabled: true
+  # replicaSC represents the storage class used for creating
+  # the pvc for the replica sts provisioned by localpv provisioner
+  replicaSC: openebs-hostpath
+  # replicas represent the desired replication factor for the jiva volume
+  replicas: 3

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -178,19 +178,6 @@ serviceAccount:
     create: true
     name: openebs-jiva-csi-node-sa
 
-analytics:
-  enabled: true
-  # Specify in hours the duration after which a ping event needs to be sent.
-  pingInterval: "24h"
-
-localpv-provisioner:
-  # Disable installation of node-disk-manager components by default
-  openebsNDM:
-    enabled: false
-  # Disable openebs-device deviceClass by default.
-  deviceClass:
-    enabled: false
-
 defaultClass:
   # Name of the default default StorageClass
   name: openebs-jiva-csi-default
@@ -211,3 +198,16 @@ defaultPolicy:
   replicaSC: openebs-hostpath
   # replicas represent the desired replication factor for the jiva volume
   replicas: 3
+
+analytics:
+  enabled: true
+  # Specify in hours the duration after which a ping event needs to be sent.
+  pingInterval: "24h"
+
+localpv-provisioner:
+  # Disable installation of node-disk-manager components by default
+  openebsNDM:
+    enabled: false
+  # Disable openebs-device deviceClass by default.
+  deviceClass:
+    enabled: false

--- a/deploy/jiva-csi.yaml
+++ b/deploy/jiva-csi.yaml
@@ -154,7 +154,9 @@ spec:
             - name: OPENEBS_JIVA_CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: OPENEBS_NAMESPACE
-              value: openebs
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: OPENEBS_NODEID
               valueFrom:
                 fieldRef:
@@ -398,7 +400,9 @@ spec:
             - name: OPENEBS_NODE_DRIVER
               value: node
             - name: OPENEBS_NAMESPACE
-              value: openebs
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             # REMOUNT: if set true/True volume will be automatically remounted
             # in case if the mountpoint goes to ro state
             - name: REMOUNT


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR adds a default jiva volume policy and a default storageclass while deploying using helm charts