### PR TITLE
feat(operator): automate movement replicas when node is removed from cluster

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: Jiva-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.9.1
+version: 2.9.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.9.0

--- a/deploy/helm/charts/templates/jiva-operator-rbac.yaml
+++ b/deploy/helm/charts/templates/jiva-operator-rbac.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- if .Values.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: jiva-operator
 rules:
@@ -24,6 +24,7 @@ rules:
   - services
   - services/finalizers
   - endpoints
+  - persistentvolumes
   - persistentvolumeclaims
   - events
   - configmaps
@@ -57,7 +58,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
+  - nodes
   verbs:
   - get
 - apiGroups:
@@ -79,7 +80,7 @@ rules:
   verbs:
   - '*'
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: openebs-jiva-operator
@@ -93,7 +94,7 @@ subjects:
   name: {{ .Values.serviceAccount.jivaOperator.name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: jiva-operator
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/deploy/helm/charts/templates/jiva-operator-rbac.yaml
+++ b/deploy/helm/charts/templates/jiva-operator-rbac.yaml
@@ -61,6 +61,8 @@ rules:
   - nodes
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3233,6 +3233,8 @@ rules:
   - nodes
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3183,7 +3183,7 @@ metadata:
   namespace: openebs
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: jiva-operator
@@ -3196,6 +3196,7 @@ rules:
   - services
   - services/finalizers
   - endpoints
+  - persistentvolumes
   - persistentvolumeclaims
   - events
   - configmaps
@@ -3229,7 +3230,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
+  - nodes
   verbs:
   - get
 - apiGroups:
@@ -3251,7 +3252,7 @@ rules:
   verbs:
   - '*'
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: jiva-operator
@@ -3260,7 +3261,7 @@ subjects:
 - kind: ServiceAccount
   name: jiva-operator
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: jiva-operator
   apiGroup: rbac.authorization.k8s.io
 ---

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3260,6 +3260,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: jiva-operator
+  namespace: openebs
 roleRef:
   kind: ClusterRole
   name: jiva-operator

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,9 +16,10 @@
 
 3. Access to install RBAC components into kube-system namespace.
 
-4. OpenEBS version 2.6.0 or higher.
+4. OpenEBS localpv version 2.6.0 or higher.
 ```
-kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml
+kubectl apply -f https://openebs.github.io/charts/openebs-operator-lite.yaml
+kubectl apply -f https://openebs.github.io/charts/openebs-lite-sc.yaml
 ```
 
 ## Install
@@ -41,15 +42,11 @@ $ kubectl get pod -n openebs
 
 NAME                                           READY   STATUS    RESTARTS   AGE
 jiva-operator-7765cbfffd-vt787                 1/1     Running   0          10s                                                             
-maya-apiserver-5c5d944d-fpkfj                  1/1     Running   2          2m5s                                                            
-openebs-admission-server-5959f9f9cd-vcwfw      1/1     Running   0          119s                                                            
 openebs-localpv-provisioner-57b44f4664-klsrw   1/1     Running   0          118s                                                            
 openebs-ndm-6dtjz                              1/1     Running   0          2m1s                                                            
 openebs-ndm-operator-f84848f77-j57vr           1/1     Running   1          2m                                                              
 openebs-ndm-qfrjf                              1/1     Running   0          2m1s                                                            
 openebs-ndm-tgpmk                              1/1     Running   0          2m1s                                                            
-openebs-provisioner-cd5759f96-jfcxb            1/1     Running   0          2m3s                                                            
-openebs-snapshot-operator-5f87bd54bf-mmtlh     2/2     Running   0          2m2s                                                            
 openebs-jiva-csi-controller-0                  4/4     Running   0          6m14s                                                           
 openebs-jiva-csi-node-56t5g                    2/2     Running   0          6m13s                                                           
 openebs-jiva-csi-node-xtyhu                    2/2     Running   0          6m20s                                                           

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,11 +16,37 @@
 
 3. Access to install RBAC components into kube-system namespace.
 
-4. OpenEBS localpv version 2.6.0 or higher.
-```
-kubectl apply -f https://openebs.github.io/charts/openebs-operator-lite.yaml
-kubectl apply -f https://openebs.github.io/charts/openebs-lite-sc.yaml
-```
+4. OpenEBS localpv-hostpath version 2.6.0 or higher.
+    ```
+    kubectl apply -f  https://openebs.github.io/charts/hostpath-operator.yaml
+    ```
+    Sample hostpath storage class
+    ```yaml
+    #Sample storage classes for OpenEBS Local PV
+    apiVersion: storage.k8s.io/v1
+    kind: StorageClass
+    metadata:
+      name: openebs-hostpath
+      annotations:
+        openebs.io/cas-type: local
+        cas.openebs.io/config: |
+          # hostpath type will create a PV by 
+          # creating a sub-directory under the
+          # BASEPATH provided below.
+          - name: StorageType
+            value: "hostpath"
+          # Specify the location (directory) where
+          # where PV(volume) data will be saved. 
+          # A sub-directory with pv-name will be 
+          # created. When the volume is deleted, 
+          # the PV sub-directory will be deleted.
+          #Default value is /var/openebs/local
+          - name: BasePath
+            value: "/var/openebs/local/"
+    provisioner: openebs.io/local
+    volumeBindingMode: WaitForFirstConsumer
+    reclaimPolicy: Delete
+    ```
 
 ## Install
 
@@ -43,20 +69,16 @@ $ kubectl get pod -n openebs
 NAME                                           READY   STATUS    RESTARTS   AGE
 jiva-operator-7765cbfffd-vt787                 1/1     Running   0          10s                                                             
 openebs-localpv-provisioner-57b44f4664-klsrw   1/1     Running   0          118s                                                            
-openebs-ndm-6dtjz                              1/1     Running   0          2m1s                                                            
-openebs-ndm-operator-f84848f77-j57vr           1/1     Running   1          2m                                                              
-openebs-ndm-qfrjf                              1/1     Running   0          2m1s                                                            
-openebs-ndm-tgpmk                              1/1     Running   0          2m1s                                                            
 openebs-jiva-csi-controller-0                  4/4     Running   0          6m14s                                                           
 openebs-jiva-csi-node-56t5g                    2/2     Running   0          6m13s                                                           
 openebs-jiva-csi-node-xtyhu                    2/2     Running   0          6m20s                                                           
-openebs-jiva-csi-node-h2unk                    2/2     Running   0          6m38s
+openebs-jiva-csi-node-h2unk                    2/2     Running   0          6m20s
 ```
 ### Steps to provision a Jiva Volume
 
 1. Create Jiva volume policy to set various policies for creating a jiva volume.
    A sample jiva volume policy CR looks like:
-   ```
+   ```yaml
     apiVersion: openebs.io/v1alpha1
     kind: JivaVolumePolicy
     metadata:
@@ -87,7 +109,7 @@ openebs-jiva-csi-node-h2unk                    2/2     Running   0          6m38
     This tutorial can be referred to create replicaSC and make use of various policies.
 
 2. Create a Storage Class to dynamically provision volumes by specifying above policy:
-   ```
+   ```yaml
    apiVersion: storage.k8s.io/v1
    kind: StorageClass
    metadata:
@@ -100,7 +122,7 @@ openebs-jiva-csi-node-h2unk                    2/2     Running   0          6m38
    ```
 
 3. Create PVC by specifying the above Storage Class in the PVC spec
-   ```
+   ```yaml
    kind: PersistentVolumeClaim
    apiVersion: v1
    metadata:
@@ -127,7 +149,7 @@ openebs-jiva-csi-node-h2unk                    2/2     Running   0          6m38
    ```
 
 4. Deploy an application using the above PVC:
-   ```
+   ```yaml
    apiVersion: apps/v1
    kind: Deployment
    metadata:

--- a/pkg/controllers/jivavolume_controller.go
+++ b/pkg/controllers/jivavolume_controller.go
@@ -269,7 +269,7 @@ func (r *JivaVolumeReconciler) moveReplicasForMissingNodes(cr *openebsiov1alpha1
 				// wait for pod to get deleted and
 				// recreated
 				time.Sleep(5 * time.Second)
-				if err != nil {
+				if err != nil && !errors.IsNotFound(err) {
 					return err
 				}
 				continue
@@ -293,6 +293,11 @@ func (r *JivaVolumeReconciler) moveReplicasForMissingNodes(cr *openebsiov1alpha1
 				// wait for pod to get deleted and
 				// recreated
 				time.Sleep(5 * time.Second)
+				r.Recorder.Eventf(cr, corev1.EventTypeWarning,
+					"ReplicaMovement",
+					"replica %s and it's corresponding PVC & PV deleted",
+					pod.Name,
+				)
 			} else {
 				return err
 			}

--- a/pkg/controllers/jivavolume_controller.go
+++ b/pkg/controllers/jivavolume_controller.go
@@ -143,6 +143,12 @@ func (r *JivaVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// to syncing which will be changed to Ready later when volume becomes RW
 	switch instance.Status.Phase {
 	case openebsiov1alpha1.JivaVolumePhaseReady:
+		// fetching the latest status before performing
+		// other operations
+		err = r.getAndUpdateVolumeStatus(instance)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 		if r.isScaleup(instance) {
 			logrus.Info("performing scaleup operation on " + instance.Name)
 			err = r.performScaleup(instance)

--- a/pkg/controllers/jivavolume_controller.go
+++ b/pkg/controllers/jivavolume_controller.go
@@ -283,7 +283,9 @@ func (r *JivaVolumeReconciler) removeSTSVolume(pvc *corev1.PersistentVolumeClaim
 	pv := &corev1.PersistentVolume{}
 	err := r.Get(context.TODO(),
 		types.NamespacedName{Name: pvc.Spec.VolumeName}, pv)
-
+	if err != nil {
+		return err
+	}
 	newPV := pv.DeepCopy()
 	newPV.ObjectMeta.Finalizers = []string{}
 	err = r.Patch(context.TODO(), newPV, client.MergeFrom(pv))

--- a/version/util.go
+++ b/version/util.go
@@ -21,6 +21,7 @@ import (
 var (
 	validCurrentVersions = map[string]bool{
 		"2.6.0": true, "2.7.0": true, "2.8.0": true, "2.9.0": true,
+		"2.10.0": true,
 	}
 	validDesiredVersion = strings.Split(Version, "-")[0]
 )


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

When a node is removed from the cluster which had a replica pod scheduled on it, then the pod remains stuck in pending state as the openebs localpv volume has node affinity for the missing node. This PR adds the automation to [clean up](https://github.com/kmova/dynamic-localpv-provisioner/blob/example-custom-affinity/docs/feature-custom-affinity.md#ephemeral-storage) the stale volume and restart the pending pod so that it moves to some new node.

Fixes: #96 

Successfully tested the scenario on AWS cluster. 