### PR TITLE
fix(analytics): send provisioning event before return

### DIFF
--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -202,6 +202,7 @@ func (cl *Client) CreateJivaVolume(req *csi.CreateVolumeRequest) (string, error)
 		if err != nil {
 			return "", status.Errorf(codes.Internal, "Failed to create JivaVolume CR, err: {%v}", err)
 		}
+		SendEventOrIgnore(pvcName, name, size.String(), "", "jiva-csi", analytics.VolumeProvision)
 		return name, nil
 	} else if err != nil {
 		return "", status.Errorf(codes.Internal, "Failed to get the JivaVolume details, err: {%v}", err)
@@ -211,7 +212,6 @@ func (cl *Client) CreateJivaVolume(req *csi.CreateVolumeRequest) (string, error)
 		return "", status.Errorf(codes.AlreadyExists, "Failed to create JivaVolume CR, volume with different size already exists")
 	}
 
-	SendEventOrIgnore(pvcName, name, size.String(), "", "jiva-csi", analytics.VolumeProvision)
 	return name, nil
 }
 


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

## Pull Request template

There was a issue that, we were returning from the createvolume method before sending the *provisioning analytics* event in case of successful volume creation.

**How the changes has been verified**

Provisioned and deprovisioned the volume and verified the events