### PR TITLE
fix(actions): skip release workflow on helm release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,11 +18,10 @@ on:
   release:
     types:
       - 'created'
-    tags:
-      - 'v*'
 
 jobs:
   csi-driver:
+    if: contains(github.ref, 'tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -102,6 +101,7 @@ jobs:
             RELEASE_TAG=${{ env.RELEASE_TAG }}
 
   jiva-operator:
+    if: contains(github.ref, 'tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR addresses the issue where a release workflow is triggered when a helm chart is released. The images pushed have tags with the name of the chart like `jiva-2.1.0` in this case. We should avoid building images in such cases. The if condition added in the workflow prevents such workflows from executing.