### PR TITLE
fix(status): fetch volume status using controller podIP

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,7 +106,8 @@ jobs:
 
       - name: Running tests
         run: |
-          kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml
+          kubectl apply -f https://openebs.github.io/charts/hostpath-operator.yaml
+          kubectl apply -f deploy/hostpath-sc.yaml
           kubectl apply -f deploy/operator.yaml
           kubectl apply -f deploy/jiva-csi.yaml
           ./ci/ci.sh

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -108,7 +108,8 @@ jobs:
 
       - name: Running tests
         run: |
-          kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml
+          kubectl apply -f https://openebs.github.io/charts/hostpath-operator.yaml
+          kubectl apply -f deploy/hostpath-sc.yaml
           kubectl apply -f deploy/operator.yaml
           kubectl apply -f deploy/jiva-csi.yaml
           ./ci/ci.sh

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -78,7 +78,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	duration := 5 * time.Second
+	duration := 30 * time.Second
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/deploy/hostpath-sc.yaml
+++ b/deploy/hostpath-sc.yaml
@@ -1,0 +1,24 @@
+#Sample storage classes for OpenEBS Local PV
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-hostpath
+  annotations:
+    openebs.io/cas-type: local
+    cas.openebs.io/config: |
+      # hostpath type will create a PV by 
+      # creating a sub-directory under the
+      # BASEPATH provided below.
+      - name: StorageType
+        value: "hostpath"
+      # Specify the location (directory) where
+      # where PV(volume) data will be saved. 
+      # A sub-directory with pv-name will be 
+      # created. When the volume is deleted, 
+      # the PV sub-directory will be deleted.
+      #Default value is /var/openebs/local
+      - name: BasePath
+        value: "/var/openebs/local/"
+provisioner: openebs.io/local
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete

--- a/pkg/controllers/jivavolume_controller.go
+++ b/pkg/controllers/jivavolume_controller.go
@@ -1254,10 +1254,13 @@ func (r *JivaVolumeReconciler) getAndUpdateVolumeStatus(cr *openebsiov1alpha1.Ji
 		return fmt.Errorf("failed to getAndUpdateVolumeStatus, err: %v", err)
 	}
 
-	podIP := podIPMap[cr.Name]
-
 	defer r.updateStatus(err, cr)
-	addr := podIP + ":9501"
+
+	addr := cr.Spec.ISCSISpec.TargetIP + ":9501"
+	if podIP, ok := podIPMap[cr.Name]; ok {
+		addr = podIP + ":9501"
+	}
+
 	if len(addr) == 0 {
 		return fmt.Errorf("failed to get volume stats: target address is empty")
 	}

--- a/pkg/controllers/jivavolume_controller.go
+++ b/pkg/controllers/jivavolume_controller.go
@@ -142,7 +142,7 @@ func (r *JivaVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			// log err only, as controller must be in container creating state
 			// don't return err as it will dump stack trace unneccesary
 			logrus.Infof("failed to get controller pod ip for volume %s: %s", instance.Name, err.Error())
-			time.Sleep(5 * time.Second)
+			time.Sleep(1 * time.Second)
 		}
 	}
 
@@ -1233,7 +1233,7 @@ func (r *JivaVolumeReconciler) getAndUpdateVolumeStatus(cr *openebsiov1alpha1.Ji
 		err = r.updatePodIPMap(cr)
 		if err != nil {
 			logrus.Infof("failed to get controller pod ip for volume %s: %s", cr.Name, err.Error())
-			time.Sleep(5 * time.Second)
+			time.Sleep(1 * time.Second)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR address 2 issues:
 - Rapidly cycling Unknown and Ready status:
     Reason: Fetching the stats using the service IP repeatedly can cause dns issues which fails occasionally and causes cycling of status
     Fix: Use controller pod IP to fetch the stats and maintain an updated map for all volumes and pod IPs 
 - Log flooding of failed tcp requests
      The above fix will help here as well

Tests covered manually:
 - volume creation and check status
 - multiple controller pod restarts 
 - multiple replica pod restarts
