### PR TITLE
refact(version): use range instead of matrix for validation

### DIFF
--- a/version/util.go
+++ b/version/util.go
@@ -27,8 +27,7 @@ var (
 // IsCurrentVersionValid verifies if the  current version is valid or not
 func IsCurrentVersionValid(v string) bool {
 	currentVersion := strings.Split(v, "-")[0]
-	return IsCurrentLessThanOrEqualNewVersion(minCurrentVersion, currentVersion) &&
-		IsCurrentLessThanOrEqualNewVersion(currentVersion, validDesiredVersion)
+	return CanCurrentVersionBeUpgraded(currentVersion)
 }
 
 // IsDesiredVersionValid verifies the desired version is valid or not
@@ -37,9 +36,16 @@ func IsDesiredVersionValid(v string) bool {
 	return validDesiredVersion == desiredVersion
 }
 
-// IsCurrentLessThanOrEqualNewVersion compares current and new version and returns true
-// if currentversion is less `<` or equal then new version
-func IsCurrentLessThanOrEqualNewVersion(old, new string) bool {
+// CanCurrentVersionBeUpgraded determines whether the current version
+// is within the range of minCurrentVersion and validDesiredVersion
+func CanCurrentVersionBeUpgraded(version string) bool {
+	return IsOldLessThanOrEqualNewVersion(minCurrentVersion, version) &&
+		IsOldLessThanOrEqualNewVersion(version, validDesiredVersion)
+}
+
+// IsOldLessThanOrEqualNewVersion compares old and new version and returns true
+// if old version is less `<` or equal then new version
+func IsOldLessThanOrEqualNewVersion(old, new string) bool {
 	oldVersions := strings.Split(strings.Split(old, "-")[0], ".")
 	newVersions := strings.Split(strings.Split(new, "-")[0], ".")
 	for i := 0; i < len(oldVersions); i++ {

--- a/version/util.go
+++ b/version/util.go
@@ -15,25 +15,40 @@ limitations under the License.
 package version
 
 import (
+	"strconv"
 	"strings"
 )
 
 var (
-	validCurrentVersions = map[string]bool{
-		"2.6.0": true, "2.7.0": true, "2.8.0": true, "2.9.0": true,
-		"2.10.0": true, "2.10.1": true, "2.11.0": true,
-	}
+	minCurrentVersion   = "2.6.0"
 	validDesiredVersion = strings.Split(Version, "-")[0]
 )
 
 // IsCurrentVersionValid verifies if the  current version is valid or not
 func IsCurrentVersionValid(v string) bool {
 	currentVersion := strings.Split(v, "-")[0]
-	return validCurrentVersions[currentVersion]
+	return IsCurrentLessThanOrEqualNewVersion(minCurrentVersion, currentVersion) &&
+		IsCurrentLessThanOrEqualNewVersion(currentVersion, validDesiredVersion)
 }
 
 // IsDesiredVersionValid verifies the desired version is valid or not
 func IsDesiredVersionValid(v string) bool {
 	desiredVersion := strings.Split(v, "-")[0]
 	return validDesiredVersion == desiredVersion
+}
+
+// IsCurrentLessThanOrEqualNewVersion compares current and new version and returns true
+// if currentversion is less `<` or equal then new version
+func IsCurrentLessThanOrEqualNewVersion(old, new string) bool {
+	oldVersions := strings.Split(strings.Split(old, "-")[0], ".")
+	newVersions := strings.Split(strings.Split(new, "-")[0], ".")
+	for i := 0; i < len(oldVersions); i++ {
+		oldVersion, _ := strconv.Atoi(oldVersions[i])
+		newVersion, _ := strconv.Atoi(newVersions[i])
+		if oldVersion == newVersion {
+			continue
+		}
+		return oldVersion < newVersion
+	}
+	return true
 }

--- a/version/util_test.go
+++ b/version/util_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package version
+
+import "testing"
+
+func TestIsCurrentVersionValid(t *testing.T) {
+	// setting the variable for test
+	validDesiredVersion = "2.9.0"
+	type args struct {
+		v string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Valid Current Version",
+			args: args{
+				v: "2.8.0",
+			},
+			want: true,
+		},
+		{
+			name: "Less than Min Current Version",
+			args: args{
+				v: "1.9.0",
+			},
+			want: false,
+		},
+		{
+			name: "More than Valid Desired Version",
+			args: args{
+				v: "2.13.0",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsCurrentVersionValid(tt.args.v); got != tt.want {
+				t.Errorf("IsCurrentVersionValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR refactors the version validation for the jivaVolume CR during upgrades. As the versionDetails in the CR is only modified by either the upgrade job or the operator itself and is not user-facing we can switch to range-based validation. We will still maintain the upgrade matrix in upgrade repo to validate the job fields. This is eliminate the need to bump the upgrade matrix on each release.

Test case covered manually: upgraded a jiva volume from 2.9.0 to latest without any issues.