### PR TITLE
fix(version): add version exceptions for upgrade ci

### DIFF
--- a/version/util.go
+++ b/version/util.go
@@ -22,6 +22,8 @@ import (
 var (
 	minCurrentVersion   = "2.6.0"
 	validDesiredVersion = strings.Split(Version, "-")[0]
+	// these are the versions used in various pipelines for ci testing
+	exceptions = []string{"master"}
 )
 
 // IsCurrentVersionValid verifies if the  current version is valid or not
@@ -48,6 +50,11 @@ func CanCurrentVersionBeUpgraded(version string) bool {
 func IsOldLessThanOrEqualNewVersion(old, new string) bool {
 	oldVersions := strings.Split(strings.Split(old, "-")[0], ".")
 	newVersions := strings.Split(strings.Split(new, "-")[0], ".")
+	for _, exception := range exceptions {
+		if newVersions[0] == exception {
+			return true
+		}
+	}
 	for i := 0; i < len(oldVersions); i++ {
 		oldVersion, _ := strconv.Atoi(oldVersions[i])
 		newVersion, _ := strconv.Atoi(newVersions[i])


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR adds `master` as an exception for version checks as it is required for the ci test in the upgrade repo
Ref:  https://github.com/openebs/upgrade/pull/120/checks?check_run_id=3217599799