### PR TITLE
Included the always block to update the test status in node failure testcase

### DIFF
--- a/e2e-tests/experiments/infra-chaos/jiva_node_failure/test.yml
+++ b/e2e-tests/experiments/infra-chaos/jiva_node_failure/test.yml
@@ -420,3 +420,11 @@
       rescue:
         - set_fact:
             flag: "Fail"
+
+      always:
+
+        - include_tasks: /e2e-tests/utils/fcm/update_e2e_result_resource.yml
+          vars:
+            status: 'EOT'
+            chaostype: "node-failure"
+            app: ""


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Included the always block to update the test status in the result crd spec.