### PR TITLE
update(yaml): update priority class name for csi driver

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for OpenEBS Jiva Operator. Jiva provides highly availabl
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.12.2
+version: 2.12.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.12.2

--- a/deploy/helm/charts/templates/priority-class.yaml
+++ b/deploy/helm/charts/templates/priority-class.yaml
@@ -3,7 +3,7 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ template "jiva.csiController.priorityClassName" . }}
-value: 900000000
+value: {{ .Values.csiController.priorityClass.value }}
 globalDefault: false
 description: "This priority class should be used for the OpenEBS CSI driver controller deployment only."
 {{- end }}
@@ -13,7 +13,7 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ template "jiva.csiNode.priorityClassName" . }}
-value: 900001000
+value: {{ .Values.csiNode.priorityClass.value }}
 globalDefault: false
 description: "This priority class should be used for the OpenEBS CSI driver node deployment only."
 {{- end }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -53,6 +53,7 @@ csiController:
   priorityClass:
     create: true
     name: jiva-csi-controller-critical
+    value: 900000000
   componentName: "openebs-jiva-csi-controller"
   attacher:
     name: "csi-attacher"
@@ -118,6 +119,7 @@ csiNode:
   priorityClass:
     create: true
     name: jiva-csi-node-critical
+    value: 900001000
   componentName: "openebs-jiva-csi-node"
   driverRegistrar:
     name: "csi-node-driver-registrar"

--- a/deploy/jiva-csi.yaml
+++ b/deploy/jiva-csi.yaml
@@ -35,7 +35,7 @@ metadata:
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: openebs-csi-controller-critical
+  name: openebs-jiva-csi-controller-critical
 value: 900000000
 globalDefault: false
 description: "This priority class should be used for the CStor CSI driver controller deployment only."
@@ -45,7 +45,7 @@ description: "This priority class should be used for the CStor CSI driver contro
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: openebs-csi-node-critical
+  name: openebs-jiva-csi-node-critical
 value: 900001000
 globalDefault: false
 description: "This priority class should be used for the CStor CSI driver node deployment only."
@@ -132,7 +132,7 @@ spec:
         openebs.io/component-name: openebs-jiva-csi-controller
         openebs.io/version: dev
     spec:
-      priorityClassName: openebs-csi-controller-critical
+      priorityClassName: openebs-jiva-csi-controller-critical
       serviceAccount: openebs-jiva-csi-controller-sa
       containers:
         - name: csi-provisioner
@@ -358,7 +358,7 @@ spec:
         openebs.io/component-name: openebs-jiva-csi-node
         openebs.io/version: dev
     spec:
-      priorityClassName: openebs-csi-node-critical
+      priorityClassName: openebs-jiva-csi-node-critical
       serviceAccount: openebs-jiva-csi-node-sa
       hostNetwork: true
       containers:


### PR DESCRIPTION
use jiva in priority class name to avoid naming clash between different storage engines.