### PR TITLE
fix[e2e]: Fixed the container count for container failure util to check the container status

### DIFF
--- a/e2e-tests/apps/minio/deployers/minio.yml
+++ b/e2e-tests/apps/minio/deployers/minio.yml
@@ -30,14 +30,6 @@ spec:
         args:
         - server
         - /storage1
-        livenessProbe:
-          exec:
-            command: 
-            - /bin/sh
-            - -c
-            - touch /storage1/healthy; sleep 2; rm -rf /storage1/healthy;
-          initialDelaySeconds: 5
-          periodSeconds: 5
         env:
         # Minio access key and secret key
         - name: MINIO_ACCESS_KEY

--- a/e2e-tests/chaoslib/openebs/jiva_csi_controller_container_kill.yml
+++ b/e2e-tests/chaoslib/openebs/jiva_csi_controller_container_kill.yml
@@ -67,7 +67,7 @@
   args:
     executable: /bin/bash
   register: runningStatusCount
-  until: "runningStatusCount.stdout == \"1\""
+  until: "runningStatusCount.stdout == \"2\""
   delay: 30
   retries: 10
 

--- a/e2e-tests/experiments/functional/data-integrity/test.yml
+++ b/e2e-tests/experiments/functional/data-integrity/test.yml
@@ -96,7 +96,7 @@
          register: result_fio_pod
          until: "'Completed' in result_fio_pod.stdout"
          delay: 15
-         retries: 30
+         retries: 60
 
        - name: Verify the fio logs to check if run is complete w/o errors
          shell: >


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

This PR fixes the below files
 - Fixed the minio deployment spec
 - Updated teh util to check the container status
 - Increased the retry timeout for data integrity check