### PR TITLE
[stable/jiva]: update jiva charts to 3.0.0 release

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -1,5 +1,6 @@
 # See https://github.com/helm/chart-testing#configuration
 remote: origin
+target-branch: develop
 chart-dirs:
   - deploy/helm
 helm-extra-args: --timeout=500s

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,10 +4,10 @@ description: Helm chart for OpenEBS Jiva Operator. Jiva provides highly availabl
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.12.3
+version: 3.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.12.2
+appVersion: 3.0.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/
 keywords:
@@ -23,7 +23,7 @@ sources:
 
 dependencies:
   - name: localpv-provisioner
-    version: "2.12.0"
+    version: "3.0.0"
     repository: "https://openebs.github.io/dynamic-localpv-provisioner"
     condition: openebsLocalpv.enabled
 

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -45,7 +45,7 @@ By default this chart installs additional, dependent charts:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 2.12.0 |
+| https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 3.0.0 |
 
 **Note:** Find detailed Dynamic LocalPV Provisioner Helm chart configuration options [here](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/deploy/helm/charts/README.md).
 
@@ -174,7 +174,7 @@ helm upgrade openebs-jiva openebs-jiva/jiva -n openebs \
 | jivaOperator.image.pullPolicy | string | `"IfNotPresent"` | Jiva operator image pull policy |
 | jivaOperator.image.registry | string | `nil` | Jiva operator image registry |
 | jivaOperator.image.repository | string | `"openebs/jiva-operator"` | Jiva operator image repository |
-| jivaOperator.image.tag | string | `"2.12.2"` |  Jiva operator image tag |
+| jivaOperator.image.tag | string | `"3.0.0"` |  Jiva operator image tag |
 | jivaOperator.nodeSelector | object | `{}` |  Jiva operator pod nodeSelector|
 | jivaOperator.podAnnotations | object | `{}` | Jiva operator pod annotations |
 | jivaOperator.resources | object | `{}` | Jiva operator pod resources |
@@ -183,12 +183,12 @@ helm upgrade openebs-jiva openebs-jiva/jiva -n openebs \
 | jivaCSIPlugin.image.pullPolicy | string | `"IfNotPresent"` | Jiva CSI driver image pull policy |
 | jivaCSIPlugin.image.registry | string | `nil` | Jiva CSI driver image registry |
 | jivaCSIPlugin.image.repository | string | `"openebs/jiva-csi"` |  Jiva CSI driver image repository |
-| jivaCSIPlugin.image.tag | string | `"2.12.2"` | Jiva CSI driver image tag |
+| jivaCSIPlugin.image.tag | string | `"3.0.0"` | Jiva CSI driver image tag |
 | jivaCSIPlugin.name | string | `"jiva-csi-plugin"` | Jiva CSI driver container name |
 | jivaCSIPlugin.remount | string | `"true"` | Jiva CSI driver remount feature, enabled by default |
 | rbac.create | bool | `true` | Enable RBAC |
 | rbac.pspEnabled | bool | `false` | Enable PodSecurityPolicy |
-| release.version | string | `"2.12.2"` | Openebs Jiva release version |
+| release.version | string | `"3.0.0"` | Openebs Jiva release version |
 | serviceAccount.annotations | object | `{}` | Service Account annotations |
 | serviceAccount.csiController.create | bool | `true` | Enable CSI Controller ServiceAccount |
 | serviceAccount.csiController.name | string | `"openebs-jiva-csi-controller-sa"` | CSI Controller ServiceAccount name |

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 release:
-  version: "2.12.2"
+  version: "3.0.0"
 
 
 # If false, openebs localpv sub-chart will not be installed
@@ -25,12 +25,12 @@ jivaOperator:
     image:
       registry:
       repository: openebs/jiva
-      tag: 2.12.2
+      tag: 3.0.0
   replica:
     image:
       registry:
       repository: openebs/jiva
-      tag: 2.12.2
+      tag: 3.0.0
   image:
     # Make sure that registry name end with a '/'.
     # For example : quay.io/ is a correct value here and quay.io is incorrect
@@ -38,7 +38,7 @@ jivaOperator:
     repository: openebs/jiva-operator
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 2.12.2
+    tag: 3.0.0
   annotations: {}
   resyncInterval: "30"
   podAnnotations: {}
@@ -112,7 +112,7 @@ jivaCSIPlugin:
     repository: openebs/jiva-csi
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 2.12.2
+    tag: 3.0.0
   remount: "true"
 
 csiNode:


### PR DESCRIPTION
Signed-off-by: shubham <shubham14bajpai@gmail.com>

**What this PR does?**:
Updates the helm chart with v3.0.0 release

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`. <!-- See examples below. -->
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Does this PR change require updating Helm Chart? If yes, mention the Helm Chart PR #<PR number>
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue  https://github.com/openebs/website is used to track them: 

<!--
PR Title format.

This repository follows semantic versioning convention, therefore each PR title/commit message must follow convention: `<type>(<scope>): <subject>`.
   `type` is defining if release will be triggering after merging submitted changes, details in [CONTRIBUTING.md](../CONTRIBUTING.md).
    Most common types are:
    * `feat`      - for new features, not a new feature for build script
    * `fix`       - for bug fixes or improvements, not a fix for build script
    * `chore`     - changes not related to production code
    * `docs`      - changes related to documentation
    * `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    * `test`      - adding missing tests, refactoring tests; no production code change
    * `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

Examples:
  feat(ha): support faster node failure detection 
  fix(provisioning): remove the duplicate labels added on volume CR
  chore(build): upgrade the go version to 1.18
  docs(user): add monitoring related user guides
  refactor(provisoining): make use of the new context api
  test(ut): handling volume deletion failures 
  test(integation): handling incorrect jiva images
  test(e2e): running nfs on jiva volumes
-->
