### PR TITLE
fix(deploy): add exporter env to jiva-operator deployment

### DIFF
--- a/build/generate-manifest.sh
+++ b/build/generate-manifest.sh
@@ -38,6 +38,9 @@ cat deploy/crds/openebs.io_jivavolumepolicies.yaml >> deploy/jiva-operator.yaml
 # Add JivaVolume v1alpha1 CRDs to the Operator yaml
 cat deploy/crds/openebs.io_jivavolumes.yaml >> deploy/jiva-operator.yaml
 
+# Add UpgradeTask v1alpha1 CRDs to the Operator yaml
+cat deploy/yamls/upgradetask.yaml >> deploy/jiva-operator.yaml
+
 # Add the jiva-operator resources to the Operator yaml
 cat deploy/yamls/operator.yaml >> deploy/jiva-operator.yaml
 

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for OpenEBS Jiva Operator. Jiva provides highly availabl
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.0
+version: 3.0.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 3.0.0

--- a/deploy/helm/charts/templates/jiva-operator.yaml
+++ b/deploy/helm/charts/templates/jiva-operator.yaml
@@ -52,8 +52,10 @@ spec:
                   fieldPath: spec.serviceAccountName
             - name: OPENEBS_IO_JIVA_CONTOLLER_IMAGE
               value: "{{ .Values.jivaOperator.controller.image.registry }}{{ .Values.jivaOperator.controller.image.repository }}:{{ .Values.jivaOperator.controller.image.tag }}"
-            - name:  OPENEBS_IO_JIVA_REPLICA_IMAGE
+            - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
               value: "{{ .Values.jivaOperator.replica.image.registry }}{{ .Values.jivaOperator.replica.image.repository }}:{{ .Values.jivaOperator.replica.image.tag }}"
+            - name: OPENEBS_IO_MAYA_EXPORTER_IMAGE
+              value: "{{ .Values.jivaOperator.exporter.image.registry }}{{ .Values.jivaOperator.exporter.image.repository }}:{{ .Values.jivaOperator.exporter.image.tag }}"
 {{- if .Values.imagePullSecrets }}
             - name: OPENEBS_IO_IMAGE_PULL_SECRETS
               value: "{{- range $.Values.imagePullSecrets }}{{ .name }},{{- end }}"

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -31,6 +31,11 @@ jivaOperator:
       registry:
       repository: openebs/jiva
       tag: 3.0.0
+  exporter:
+    image:
+      registry:
+      repository: openebs/m-exporter
+      tag: 3.0.0
   image:
     # Make sure that registry name end with a '/'.
     # For example : quay.io/ is a correct value here and quay.io is incorrect

--- a/deploy/jiva-operator.yaml
+++ b/deploy/jiva-operator.yaml
@@ -3168,6 +3168,264 @@ status:
   storedVersions: []
 
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: upgradetasks.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: UpgradeTask
+    listKind: UpgradeTaskList
+    plural: upgradetasks
+    singular: upgradetask
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: UpgradeTask represents an upgrade task
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec i.e. specifications of the UpgradeTask
+            properties:
+              cstorPool:
+                description: CStorPool contains the details of the cstor pool to be
+                  upgraded
+                properties:
+                  options:
+                    description: Options can be used to change the default behaviour
+                      of upgrade
+                    properties:
+                      ignoreStepsOnError:
+                        description: IgnoreStepsOnError allows to ignore steps which
+                          failed
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  poolName:
+                    description: PoolName contains the name of the cstor pool to be
+                      upgraded
+                    type: string
+                type: object
+              cstorPoolCluster:
+                description: CStorPoolCluster contains the details of the storage
+                  pool claim to be upgraded
+                properties:
+                  cspcName:
+                    description: CSPCName contains the name of the storage pool claim
+                      to be upgraded
+                    type: string
+                  options:
+                    description: Options can be used to change the default behaviour
+                      of upgrade
+                    properties:
+                      ignoreStepsOnError:
+                        description: IgnoreStepsOnError allows to ignore steps which
+                          failed
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              cstorPoolInstance:
+                description: CStorPoolInstance contains the details of the cstor pool
+                  to be upgraded
+                properties:
+                  cspiName:
+                    description: CSPCName contains the name of the storage pool claim
+                      to be upgraded
+                    type: string
+                  options:
+                    description: Options can be used to change the default behaviour
+                      of upgrade
+                    properties:
+                      ignoreStepsOnError:
+                        description: IgnoreStepsOnError allows to ignore steps which
+                          failed
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              cstorVolume:
+                description: CStorVolume contains the details of the cstor volume
+                  to be upgraded
+                properties:
+                  options:
+                    description: Options can be used to change the default behaviour
+                      of upgrade
+                    properties:
+                      ignoreStepsOnError:
+                        description: IgnoreStepsOnError allows to ignore steps which
+                          failed
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  pvName:
+                    description: PVName contains the name of the pv associated with
+                      the cstor volume
+                    type: string
+                type: object
+              fromVersion:
+                description: FromVersion is the current version of the resource.
+                type: string
+              imagePrefix:
+                description: ImagePrefix contains the url prefix of the image url.
+                  This field is optional. If not present upgrade takes the previously
+                  present ImagePrefix.
+                type: string
+              imageTag:
+                description: ImageTag contains the customized tag for ToVersion if
+                  any. This field is optional. If not present upgrade takes the ToVersion
+                  as the ImageTag
+                type: string
+              jivaVolume:
+                description: JivaVolume contains the details of the jiva volume to
+                  be upgraded
+                properties:
+                  options:
+                    description: Options can be used to change the default behaviour
+                      of upgrade
+                    properties:
+                      ignoreStepsOnError:
+                        description: IgnoreStepsOnError allows to ignore steps which
+                          failed
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  pvName:
+                    description: PVName contains the name of the pv associated with
+                      the jiva volume
+                    type: string
+                type: object
+              options:
+                description: Options contains the optional flags that can be passed
+                  during upgrade.
+                properties:
+                  timeout:
+                    description: Timeout is maximum seconds to wait at any given step
+                      in the upgrade
+                    type: integer
+                type: object
+              storagePoolClaim:
+                description: StoragePoolClaim contains the details of the storage
+                  pool claim to be upgraded
+                properties:
+                  options:
+                    description: Options can be used to change the default behaviour
+                      of upgrade
+                    properties:
+                      ignoreStepsOnError:
+                        description: IgnoreStepsOnError allows to ignore steps which
+                          failed
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  spcName:
+                    description: SPCName contains the name of the storage pool claim
+                      to be upgraded
+                    type: string
+                type: object
+              toVersion:
+                description: ToVersion is the upgraded version of the resource. It
+                  should be same as the version of control plane components version.
+                type: string
+            required:
+            - fromVersion
+            - toVersion
+            type: object
+          status:
+            description: Status of UpgradeTask
+            properties:
+              completedTime:
+                description: CompletedTime of Upgrade
+                format: date-time
+                nullable: true
+                type: string
+              phase:
+                description: Phase indicates if a upgradeTask is started, success
+                  or errored
+                type: string
+              retries:
+                description: Retries is the number of times the job attempted to upgrade
+                  the resource
+                type: integer
+              startTime:
+                description: StartTime of Upgrade
+                format: date-time
+                nullable: true
+                type: string
+              upgradeDetailedStatuses:
+                description: UpgradeDetailedStatuses contains the list of statuses
+                  of each step
+                items:
+                  description: UpgradeDetailedStatuses represents the latest available
+                    observations of a UpgradeTask current state.
+                  properties:
+                    lastUpdatedAt:
+                      description: LastUpdatedTime of a UpgradeStep
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: A human-readable message indicating details about
+                        why the upgradeStep is in this state
+                      type: string
+                    phase:
+                      description: Phase indicates if the UpgradeStep is waiting,
+                        errored or completed.
+                      type: string
+                    reason:
+                      description: Reason is a brief CamelCase string that describes
+                        any failure and is meant for machine parsing and tidy display
+                        in the CLI
+                      type: string
+                    startTime:
+                      description: StartTime of a UpgradeStep
+                      format: date-time
+                      nullable: true
+                      type: string
+                    step:
+                      description: UpgradeStep is the current step being performed
+                        for a particular resource upgrade
+                      type: string
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/jiva-operator.yaml
+++ b/deploy/jiva-operator.yaml
@@ -3308,6 +3308,8 @@ spec:
               value: "openebs/jiva:ci"
             - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
               value: "openebs/jiva:ci"
+            - name: OPENEBS_IO_MAYA_EXPORTER_IMAGE
+              value: "openebs/m-exporter:ci"
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/yamls/operator.yaml
+++ b/deploy/yamls/operator.yaml
@@ -140,6 +140,8 @@ spec:
               value: "openebs/jiva:ci"
             - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
               value: "openebs/jiva:ci"
+            - name: OPENEBS_IO_MAYA_EXPORTER_IMAGE
+              value: "openebs/m-exporter:ci"
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/yamls/upgradetask.yaml
+++ b/deploy/yamls/upgradetask.yaml
@@ -1,0 +1,258 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: upgradetasks.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: UpgradeTask
+    listKind: UpgradeTaskList
+    plural: upgradetasks
+    singular: upgradetask
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: UpgradeTask represents an upgrade task
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec i.e. specifications of the UpgradeTask
+            properties:
+              cstorPool:
+                description: CStorPool contains the details of the cstor pool to be
+                  upgraded
+                properties:
+                  options:
+                    description: Options can be used to change the default behaviour
+                      of upgrade
+                    properties:
+                      ignoreStepsOnError:
+                        description: IgnoreStepsOnError allows to ignore steps which
+                          failed
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  poolName:
+                    description: PoolName contains the name of the cstor pool to be
+                      upgraded
+                    type: string
+                type: object
+              cstorPoolCluster:
+                description: CStorPoolCluster contains the details of the storage
+                  pool claim to be upgraded
+                properties:
+                  cspcName:
+                    description: CSPCName contains the name of the storage pool claim
+                      to be upgraded
+                    type: string
+                  options:
+                    description: Options can be used to change the default behaviour
+                      of upgrade
+                    properties:
+                      ignoreStepsOnError:
+                        description: IgnoreStepsOnError allows to ignore steps which
+                          failed
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              cstorPoolInstance:
+                description: CStorPoolInstance contains the details of the cstor pool
+                  to be upgraded
+                properties:
+                  cspiName:
+                    description: CSPCName contains the name of the storage pool claim
+                      to be upgraded
+                    type: string
+                  options:
+                    description: Options can be used to change the default behaviour
+                      of upgrade
+                    properties:
+                      ignoreStepsOnError:
+                        description: IgnoreStepsOnError allows to ignore steps which
+                          failed
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              cstorVolume:
+                description: CStorVolume contains the details of the cstor volume
+                  to be upgraded
+                properties:
+                  options:
+                    description: Options can be used to change the default behaviour
+                      of upgrade
+                    properties:
+                      ignoreStepsOnError:
+                        description: IgnoreStepsOnError allows to ignore steps which
+                          failed
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  pvName:
+                    description: PVName contains the name of the pv associated with
+                      the cstor volume
+                    type: string
+                type: object
+              fromVersion:
+                description: FromVersion is the current version of the resource.
+                type: string
+              imagePrefix:
+                description: ImagePrefix contains the url prefix of the image url.
+                  This field is optional. If not present upgrade takes the previously
+                  present ImagePrefix.
+                type: string
+              imageTag:
+                description: ImageTag contains the customized tag for ToVersion if
+                  any. This field is optional. If not present upgrade takes the ToVersion
+                  as the ImageTag
+                type: string
+              jivaVolume:
+                description: JivaVolume contains the details of the jiva volume to
+                  be upgraded
+                properties:
+                  options:
+                    description: Options can be used to change the default behaviour
+                      of upgrade
+                    properties:
+                      ignoreStepsOnError:
+                        description: IgnoreStepsOnError allows to ignore steps which
+                          failed
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  pvName:
+                    description: PVName contains the name of the pv associated with
+                      the jiva volume
+                    type: string
+                type: object
+              options:
+                description: Options contains the optional flags that can be passed
+                  during upgrade.
+                properties:
+                  timeout:
+                    description: Timeout is maximum seconds to wait at any given step
+                      in the upgrade
+                    type: integer
+                type: object
+              storagePoolClaim:
+                description: StoragePoolClaim contains the details of the storage
+                  pool claim to be upgraded
+                properties:
+                  options:
+                    description: Options can be used to change the default behaviour
+                      of upgrade
+                    properties:
+                      ignoreStepsOnError:
+                        description: IgnoreStepsOnError allows to ignore steps which
+                          failed
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  spcName:
+                    description: SPCName contains the name of the storage pool claim
+                      to be upgraded
+                    type: string
+                type: object
+              toVersion:
+                description: ToVersion is the upgraded version of the resource. It
+                  should be same as the version of control plane components version.
+                type: string
+            required:
+            - fromVersion
+            - toVersion
+            type: object
+          status:
+            description: Status of UpgradeTask
+            properties:
+              completedTime:
+                description: CompletedTime of Upgrade
+                format: date-time
+                nullable: true
+                type: string
+              phase:
+                description: Phase indicates if a upgradeTask is started, success
+                  or errored
+                type: string
+              retries:
+                description: Retries is the number of times the job attempted to upgrade
+                  the resource
+                type: integer
+              startTime:
+                description: StartTime of Upgrade
+                format: date-time
+                nullable: true
+                type: string
+              upgradeDetailedStatuses:
+                description: UpgradeDetailedStatuses contains the list of statuses
+                  of each step
+                items:
+                  description: UpgradeDetailedStatuses represents the latest available
+                    observations of a UpgradeTask current state.
+                  properties:
+                    lastUpdatedAt:
+                      description: LastUpdatedTime of a UpgradeStep
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: A human-readable message indicating details about
+                        why the upgradeStep is in this state
+                      type: string
+                    phase:
+                      description: Phase indicates if the UpgradeStep is waiting,
+                        errored or completed.
+                      type: string
+                    reason:
+                      description: Reason is a brief CamelCase string that describes
+                        any failure and is meant for machine parsing and tidy display
+                        in the CLI
+                      type: string
+                    startTime:
+                      description: StartTime of a UpgradeStep
+                      format: date-time
+                      nullable: true
+                      type: string
+                    step:
+                      description: UpgradeStep is the current step being performed
+                        for a particular resource upgrade
+                      type: string
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+


### PR DESCRIPTION
Signed-off-by: shubham <shubham14bajpai@gmail.com>

**What this PR does?**:
This PR fixes the missing exporter env from the jiva-operator deployment

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`. <!-- See examples below. -->
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Does this PR change require updating Helm Chart? If yes, mention the Helm Chart PR #<PR number>
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue  https://github.com/openebs/website is used to track them: 

<!--
PR Title format.

This repository follows semantic versioning convention, therefore each PR title/commit message must follow convention: `<type>(<scope>): <subject>`.
   `type` is defining if release will be triggering after merging submitted changes, details in [CONTRIBUTING.md](../CONTRIBUTING.md).
    Most common types are:
    * `feat`      - for new features, not a new feature for build script
    * `fix`       - for bug fixes or improvements, not a fix for build script
    * `chore`     - changes not related to production code
    * `docs`      - changes related to documentation
    * `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    * `test`      - adding missing tests, refactoring tests; no production code change
    * `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

Examples:
  feat(ha): support faster node failure detection 
  fix(provisioning): remove the duplicate labels added on volume CR
  chore(build): upgrade the go version to 1.18
  docs(user): add monitoring related user guides
  refactor(provisoining): make use of the new context api
  test(ut): handling volume deletion failures 
  test(integation): handling incorrect jiva images
  test(e2e): running nfs on jiva volumes
-->
