### PR TITLE
fix(helm): Reverse override order of the logLevel settings

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart for OpenEBS Jiva Operator. Jiva provides highly availabl
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.3
+version: 3.0.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 3.0.0

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -113,7 +113,7 @@ helm upgrade openebs-jiva openebs-jiva/jiva -n openebs \
 | csiController.attacher.image.registry | string | `"k8s.gcr.io/"` |  CSI attacher image registry |
 | csiController.attacher.image.repository | string | `"k8scsi/csi-attacher"` |  CSI attacher image repo |
 | csiController.attacher.image.tag | string | `"v3.1.0"` | CSI attacher image tag |
-| csiController.attacher.logLevel | string | `"5"` |  CSI attacher container log level (1 = least verbose, 5 = most verbose)|
+| csiController.attacher.logLevel | string | _unspecified_ |  Override CSI attacher container log level (1 = least verbose, 5 = most verbose) |
 | csiController.attacher.name | string | `"csi-attacher"` |  CSI attacher container name|
 | csiController.componentName | string | `""` | CSI controller component name |
 | csiController.driverRegistrar.image.pullPolicy | string | `"IfNotPresent"` | CSI driver registrar image pull policy  |
@@ -126,20 +126,20 @@ helm upgrade openebs-jiva openebs-jiva/jiva -n openebs \
 | csiController.livenessprobe.image.repository | string | `"k8scsi/livenessprobe"` |  CSI livenessprobe image repo |
 | csiController.livenessprobe.image.tag | string | `"v2.3.0"` | CSI livenessprobe image tag |
 | csiController.livenessprobe.name | string | `"liveness-probe"` |  CSI livenessprobe container name|
-| csiController.logLevel | string | _unspecified_ |  Log level for all CSI controller containers (1 = least verbose, 5 = most verbose) - overrides the per-container defaults |
+| csiController.logLevel | string | `"5"` | Default log level for all CSI controller containers (1 = least verbose, 5 = most verbose) unless overridden for a specific container |
 | csiController.nodeSelector | object | `{}` |  CSI controller pod node selector |
 | csiController.podAnnotations | object | `{}` | CSI controller pod annotations |
 | csiController.provisioner.image.pullPolicy | string | `"IfNotPresent"` | CSI provisioner image pull policy |
 | csiController.provisioner.image.registry | string | `"k8s.gcr.io/"` | CSI provisioner image pull registry |
 | csiController.provisioner.image.repository | string | `"k8scsi/csi-provisioner"` | CSI provisioner image pull repository |
 | csiController.provisioner.image.tag | string | `"v3.0.0"` | CSI provisioner image tag |
-| csiController.provisioner.logLevel | string | `"5"` |  CSI provisioner container log level (1 = least verbose, 5 = most verbose)|
+| csiController.provisioner.logLevel | string | _unspecified_ | Override CSI provisioner container log level (1 = least verbose, 5 = most verbose) |
 | csiController.provisioner.name | string | `"csi-provisioner"` | CSI provisioner container name |
 | csiController.resizer.image.pullPolicy | string | `"IfNotPresent"` | CSI resizer image pull policy  |
 | csiController.resizer.image.registry | string | `"k8s.gcr.io/"` | CSI resizer image registry |
 | csiController.resizer.image.repository | string | `"k8scsi/csi-resizer"` |  CSI resizer image repository|
 | csiController.resizer.image.tag | string | `"v1.2.0"` | CSI resizer image tag |
-| csiController.resizer.logLevel | string | `"5"` |  CSI resizer container log level (1 = least verbose, 5 = most verbose)|
+| csiController.resizer.logLevel | string | _unspecified_ | Override CSI resizer container log level (1 = least verbose, 5 = most verbose) |
 | csiController.resizer.name | string | `"csi-resizer"` | CSI resizer container name |
 | csiController.resources | object | `{}` | CSI controller container resources |
 | csiController.securityContext | object | `{}` | CSI controller security context |
@@ -151,9 +151,10 @@ helm upgrade openebs-jiva openebs-jiva/jiva -n openebs \
 | csiNode.driverRegistrar.image.repository | string | `"k8scsi/csi-node-driver-registrar"` | CSI Node driver registrar image repository |
 | csiNode.driverRegistrar.image.tag | string | `"v2.3.0"` |  CSI Node driver registrar image tag|
 | csiNode.driverRegistrar.name | string | `"csi-node-driver-registrar"` | CSI Node driver registrar container name |
-| csiNode.driverRegistrar.logLevel | string | `"5"` |  CSI node driver registrar container log level (1 = least verbose, 5 = most verbose)|
+| csiNode.driverRegistrar.logLevel | string | _unspecified_ | Override CSI node driver registrar container log level (1 = least verbose, 5 = most verbose) |
 | csiNode.kubeletDir | string | `"/var/lib/kubelet/"` | Kubelet root dir |
 | csiNode.labels | object | `{}` | CSI Node pod labels |
+| csiNode.logLevel | string | `"5"` | Default log level for all CSI node pod containers (1 = least verbose, 5 = most verbose) unless overridden for a specific container |
 | csiNode.nodeSelector | object | `{}` |   CSI Node pod nodeSelector |
 | csiNode.podAnnotations | object | `{}` | CSI Node pod annotations |
 | csiNode.resources | object | `{}` | CSI Node pod resources |

--- a/deploy/helm/charts/templates/csi-controller.yaml
+++ b/deploy/helm/charts/templates/csi-controller.yaml
@@ -29,7 +29,7 @@ spec:
           resources:
 {{ toYaml .Values.csiController.resources | indent 12 }}
           args:
-            - "--v={{ .Values.csiController.logLevel | default .Values.csiController.resizer.logLevel }}"
+            - "--v={{ .Values.csiController.resizer.logLevel | default .Values.csiController.logLevel }}"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
           env:
@@ -44,7 +44,7 @@ spec:
           imagePullPolicy: {{ .Values.csiController.provisioner.image.pullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--v={{ .Values.csiController.logLevel | default .Values.csiController.provisioner.logLevel }}"
+            - "--v={{ .Values.csiController.provisioner.logLevel | default .Values.csiController.logLevel }}"
             - "--feature-gates=Topology=true"
             - "--extra-create-metadata=true"
             - "--metrics-address=:22011"
@@ -64,7 +64,7 @@ spec:
           image: "{{ .Values.csiController.attacher.image.registry }}{{ .Values.csiController.attacher.image.repository }}:{{ .Values.csiController.attacher.image.tag }}"
           imagePullPolicy: {{ .Values.csiController.attacher.image.pullPolicy }}
           args:
-            - "--v={{ .Values.csiController.logLevel | default .Values.csiController.attacher.logLevel }}"
+            - "--v={{ .Values.csiController.attacher.logLevel | default .Values.csiController.logLevel }}"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS

--- a/deploy/helm/charts/templates/csi-node.yaml
+++ b/deploy/helm/charts/templates/csi-node.yaml
@@ -29,7 +29,7 @@ spec:
           resources:
 {{ toYaml .Values.csiNode.resources | indent 12 }}
           args:
-            - "--v={{ .Values.csiNode.logLevel | default .Values.csiNode.driverRegistrar.logLevel }}"
+            - "--v={{ .Values.csiNode.driverRegistrar.logLevel | default .Values.csiNode.logLevel }}"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
           lifecycle:

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -60,6 +60,7 @@ csiController:
     name: jiva-csi-controller-critical
     value: 900000000
   componentName: "openebs-jiva-csi-controller"
+  logLevel: "5"
   attacher:
     name: "csi-attacher"
     image:
@@ -70,7 +71,6 @@ csiController:
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
       tag: v3.1.0
-    logLevel: "5"
   livenessprobe:
     name: "liveness-probe"
     image:
@@ -91,7 +91,6 @@ csiController:
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
       tag: v3.0.0
-    logLevel: "5"
   resizer:
     name: "csi-resizer"
     image:
@@ -102,7 +101,6 @@ csiController:
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
       tag: v1.2.0
-    logLevel: "5"
   annotations: {}
   podAnnotations: {}
   podLabels: {}
@@ -129,6 +127,7 @@ csiNode:
     name: jiva-csi-node-critical
     value: 900001000
   componentName: "openebs-jiva-csi-node"
+  logLevel: "5"
   driverRegistrar:
     name: "csi-node-driver-registrar"
     image:
@@ -137,7 +136,6 @@ csiNode:
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
       tag: v2.3.0
-    logLevel: "5"
   livenessprobe:
     name: "liveness-probe"
     image:


### PR DESCRIPTION
This is a modification to #161 to reverse the order of the overriding between `csiController.logLevel` and `csiController.<container>.logLevel` following discussions on openebs/cstor-operators#397.  Now `csiController.logLevel` sets a default at the pod level, and `csiController.*.logLevel` overrides that default for the relevant pod.

**Why is this PR required? What issue does it fix?**:

I recently created PR #161 to allow configuration of log level settings, and in the version I initially committed the pod-level `csiController.logLevel` setting would override the container-level `csiController.<container>.logLevel`.  I ported the same change over to cstor as openebs/cstor-operators#397 but discussions over there came out in favour of the override working the other way around, i.e. the pod-level setting is a default but individual container settings can override that.

**What this PR does?**:

This PR brings the Jiva chart into line with the accepted change to the cstor one.

**Does this PR require any upgrade changes?**:

No - the only scenario this would break is if someone has

- used chart version 3.0.3
- overridden `csiController.logLevel` _and_
- also set `csiController.something.logLevel`

Nobody will have actually done this, since in 3.0.3 the pod-level setting wins (so you wouldn't set both together anyway).  Someone who has set _only_ the pod-level value will see no change in behaviour with this PR.

**Checklist:**
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`. <!-- See examples below. -->
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
