### PR TITLE
refactor(operator): use a common label (jivaAPI) to reference jiva api

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -28,7 +28,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	api "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"
+	jivaAPI "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"
 	"github.com/openebs/jiva-operator/pkg/controllers"
 	"github.com/openebs/jiva-operator/version"
 	"github.com/sirupsen/logrus"
@@ -48,7 +48,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(api.AddToScheme(scheme))
+	utilruntime.Must(jivaAPI.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/pkg/apis/addtoscheme_openebs_v1.go
+++ b/pkg/apis/addtoscheme_openebs_v1.go
@@ -17,10 +17,10 @@ limitations under the License.
 package apis
 
 import (
-	api "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"
+	jivaAPI "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"
 )
 
 func init() {
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
-	AddToSchemes = append(AddToSchemes, api.SchemeBuilder.AddToScheme)
+	AddToSchemes = append(AddToSchemes, jivaAPI.SchemeBuilder.AddToScheme)
 }

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	jv "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"
+	jivaAPI "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"
 	"github.com/openebs/jiva-operator/pkg/jiva"
 	"github.com/openebs/jiva-operator/pkg/kubernetes/client"
 	analytics "github.com/openebs/jiva-operator/pkg/usage"
@@ -218,9 +218,9 @@ func (cs *controller) ControllerGetCapabilities(
 	return resp, nil
 }
 
-func (cs *controller) isVolumeReady(volumeID string) (*jv.JivaVolume, error) {
+func (cs *controller) isVolumeReady(volumeID string) (*jivaAPI.JivaVolume, error) {
 	var interval time.Duration = 0
-	var instance *jv.JivaVolume
+	var instance *jivaAPI.JivaVolume
 	var i int
 	for i = 0; i <= MaxRetryCount; i++ {
 		if i == MaxRetryCount {

--- a/pkg/driver/mount.go
+++ b/pkg/driver/mount.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	jv "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"
+	jivaAPI "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	utilexec "k8s.io/utils/exec"
@@ -84,7 +84,7 @@ func (m *NodeMounter) GetDeviceName(mountPath string) (string, int, error) {
 	return mount.GetDeviceNameFromMount(m, mountPath)
 }
 
-func doesVolumeExist(volID string, cli *client.Client) (*jv.JivaVolume, error) {
+func doesVolumeExist(volID string, cli *client.Client) (*jivaAPI.JivaVolume, error) {
 	volID = utils.StripName(volID)
 	if err := cli.Set(); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -105,7 +105,7 @@ func isVolumeReady(volID string, cli *client.Client) (bool, error) {
 		return false, err
 	}
 
-	if instance.Status.Phase == jv.JivaVolumePhaseReady && instance.Status.Status == "RW" {
+	if instance.Status.Phase == jivaAPI.JivaVolumePhaseReady && instance.Status.Status == "RW" {
 		return true, nil
 	}
 	return false, nil
@@ -123,7 +123,7 @@ func isVolumeReachable(targetPortal string) bool {
 	return false
 }
 
-func waitForVolumeToBeReady(volID string, cli *client.Client) (*jv.JivaVolume, error) {
+func waitForVolumeToBeReady(volID string, cli *client.Client) (*jivaAPI.JivaVolume, error) {
 	var retry int
 	var sleepInterval time.Duration = 0
 	for {
@@ -134,7 +134,7 @@ func waitForVolumeToBeReady(volID string, cli *client.Client) (*jv.JivaVolume, e
 		}
 
 		retry++
-		if instance.Status.Phase == jv.JivaVolumePhaseReady && instance.Status.Status == "RW" {
+		if instance.Status.Phase == jivaAPI.JivaVolumePhaseReady && instance.Status.Status == "RW" {
 			return instance, nil
 		} else if retry <= MaxRetryCount {
 			sleepInterval = 5
@@ -215,7 +215,7 @@ func (n *NodeMounter) MonitorMounts() {
 	logrus.Infof("Starting MonitorMounts goroutine")
 	var (
 		err        error
-		csivolList *jv.JivaVolumeList
+		csivolList *jivaAPI.JivaVolumeList
 		mountList  []mount.MountPoint
 	)
 	ticker := time.NewTicker(MonitorMountRetryTimeout * time.Second)
@@ -291,7 +291,7 @@ func verifyMountOpts(opts []string, desiredOpt string) bool {
 	return false
 }
 
-func (n *NodeMounter) remount(vol jv.JivaVolume, stagingPathExists, targetPathExists bool) {
+func (n *NodeMounter) remount(vol jivaAPI.JivaVolume, stagingPathExists, targetPathExists bool) {
 	defer func() {
 		request.TransitionVolListLock.Lock()
 		delete(request.TransitionVolList, vol.Name)
@@ -320,7 +320,7 @@ func (n *NodeMounter) remount(vol jv.JivaVolume, stagingPathExists, targetPathEx
 // the disk will be attached via iSCSI login and then it will be mounted
 func (n *NodeMounter) remountVolume(
 	stagingPathExists bool, targetPathExists bool,
-	vol *jv.JivaVolume,
+	vol *jivaAPI.JivaVolume,
 ) (err error) {
 	options := []string{"rw"}
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/kubernetes-csi/csi-lib-iscsi/iscsi"
-	jv "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"
+	jivaAPI "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"
 	"github.com/openebs/jiva-operator/pkg/kubernetes/client"
 	"github.com/openebs/jiva-operator/pkg/request"
 	"github.com/openebs/jiva-operator/pkg/utils"
@@ -97,7 +97,7 @@ func NewNode(d *CSIDriver, cli *client.Client) *node {
 	}
 }
 
-func (ns *node) attachDisk(instance *jv.JivaVolume) (string, error) {
+func (ns *node) attachDisk(instance *jivaAPI.JivaVolume) (string, error) {
 	connector := iscsi.Connector{
 		VolumeName:    instance.Name,
 		TargetIqn:     instance.Spec.ISCSISpec.Iqn,
@@ -279,7 +279,7 @@ update:
 	return &csi.NodeStageVolumeResponse{}, nil
 }
 
-func (ns *node) doesVolumeExist(volID string) (*jv.JivaVolume, error) {
+func (ns *node) doesVolumeExist(volID string) (*jivaAPI.JivaVolume, error) {
 	volID = utils.StripName(volID)
 	if err := ns.client.Set(); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/jivavolume/jivavolume.go
+++ b/pkg/jivavolume/jivavolume.go
@@ -20,25 +20,25 @@ import (
 	"errors"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	jv "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"
+	jivaAPI "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"
 	"github.com/openebs/jiva-operator/version"
 )
 
 // Jiva wraps the JivaVolume structure
 type Jiva struct {
-	jvObj *jv.JivaVolume
+	jvObj *jivaAPI.JivaVolume
 	Errs  []error
 }
 
 // New returns new instance of Jiva which is wrapper over JivaVolume
 func New() *Jiva {
 	return &Jiva{
-		jvObj: &jv.JivaVolume{},
+		jvObj: &jivaAPI.JivaVolume{},
 	}
 }
 
 // Instance returns the instance of JivaVolume
-func (j *Jiva) Instance() *jv.JivaVolume {
+func (j *Jiva) Instance() *jivaAPI.JivaVolume {
 	return j.jvObj
 }
 

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/openebs/jiva-operator/pkg/apis"
-	jv "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"
+	jivaAPI "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"
 	"github.com/openebs/jiva-operator/pkg/jivavolume"
 	analytics "github.com/openebs/jiva-operator/pkg/usage"
 	"github.com/openebs/jiva-operator/pkg/utils"
@@ -103,7 +103,7 @@ func (cl *Client) RegisterAPI(opts manager.Options) error {
 }
 
 // GetJivaVolume get the instance of JivaVolume CR.
-func (cl *Client) GetJivaVolume(name string) (*jv.JivaVolume, error) {
+func (cl *Client) GetJivaVolume(name string) (*jivaAPI.JivaVolume, error) {
 	instance, err := cl.ListJivaVolume(name)
 	if err != nil {
 		logrus.Errorf("Failed to get JivaVolume CR: %v, err: %v", name, err)
@@ -118,7 +118,7 @@ func (cl *Client) GetJivaVolume(name string) (*jv.JivaVolume, error) {
 }
 
 // UpdateJivaVolume update the JivaVolume CR
-func (cl *Client) UpdateJivaVolume(cr *jv.JivaVolume) (bool, error) {
+func (cl *Client) UpdateJivaVolume(cr *jivaAPI.JivaVolume) (bool, error) {
 	err := cl.client.Update(context.TODO(), cr)
 	if err != nil {
 		if k8serrors.IsConflict(err) {
@@ -198,7 +198,7 @@ func (cl *Client) CreateJivaVolume(req *csi.CreateVolumeRequest) (string, error)
 	}
 
 	obj := jiva.Instance()
-	objExists := &jv.JivaVolume{}
+	objExists := &jivaAPI.JivaVolume{}
 	err = cl.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: ns}, objExists)
 	if err != nil && k8serrors.IsNotFound(err) {
 		logrus.Infof("Creating a new JivaVolume CR {name: %v, namespace: %v}", name, ns)
@@ -220,9 +220,9 @@ func (cl *Client) CreateJivaVolume(req *csi.CreateVolumeRequest) (string, error)
 }
 
 // ListJivaVolume returns the list of JivaVolume resources
-func (cl *Client) ListJivaVolume(volumeID string) (*jv.JivaVolumeList, error) {
+func (cl *Client) ListJivaVolume(volumeID string) (*jivaAPI.JivaVolumeList, error) {
 	volumeID = utils.StripName(volumeID)
-	obj := &jv.JivaVolumeList{}
+	obj := &jivaAPI.JivaVolumeList{}
 	opts := []client.ListOption{
 		client.MatchingLabels(getDefaultLabels(volumeID, "")),
 	}
@@ -235,9 +235,9 @@ func (cl *Client) ListJivaVolume(volumeID string) (*jv.JivaVolumeList, error) {
 }
 
 // GetJivaVolume returns the list of JivaVolume resources
-func (cl *Client) GetJivaVolumeResource(volumeID string) (*jv.JivaVolume, error) {
+func (cl *Client) GetJivaVolumeResource(volumeID string) (*jivaAPI.JivaVolume, error) {
 	volumeID = utils.StripName(volumeID)
-	obj := &jv.JivaVolume{}
+	obj := &jivaAPI.JivaVolume{}
 
 	if err := cl.client.Get(context.TODO(), types.NamespacedName{Name: volumeID, Namespace: GetOpenEBSNamespace()}, obj); err != nil {
 		return nil, err
@@ -247,8 +247,8 @@ func (cl *Client) GetJivaVolumeResource(volumeID string) (*jv.JivaVolume, error)
 }
 
 // ListJivaVolumeWithOpts returns the list of JivaVolume resources
-func (cl *Client) ListJivaVolumeWithOpts(opts map[string]string) (*jv.JivaVolumeList, error) {
-	obj := &jv.JivaVolumeList{}
+func (cl *Client) ListJivaVolumeWithOpts(opts map[string]string) (*jivaAPI.JivaVolumeList, error) {
+	obj := &jivaAPI.JivaVolumeList{}
 	options := []client.ListOption{
 		client.MatchingLabels(opts),
 	}


### PR DESCRIPTION
resolves #169

Signed-off-by: Abhishek Singh Baghel <abhib@microsoft.com>

**Why is this PR required? What issue does it fix?**:
_Fixes #169

**What this PR does?**:
Updates code base to use jivaAPI as a common label to reference "github.com/openebs/jiva-operator/pkg/apis/openebs/v1"

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`. <!-- See examples below. -->
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Does this PR change require updating Helm Chart? If yes, mention the Helm Chart PR #<PR number>
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue  https://github.com/openebs/website is used to track them: 

<!--
PR Title format.

This repository follows semantic versioning convention, therefore each PR title/commit message must follow convention: `<type>(<scope>): <subject>`.
   `type` is defining if release will be triggering after merging submitted changes, details in [CONTRIBUTING.md](../CONTRIBUTING.md).
    Most common types are:
    * `feat`      - for new features, not a new feature for build script
    * `fix`       - for bug fixes or improvements, not a fix for build script
    * `chore`     - changes not related to production code
    * `docs`      - changes related to documentation
    * `style`     - formatting, missing semi colons, linting fix etc; no significant production code changes
    * `test`      - adding missing tests, refactoring tests; no production code change
    * `refactor`  - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes

Examples:
  feat(ha): support faster node failure detection 
  fix(provisioning): remove the duplicate labels added on volume CR
  chore(build): upgrade the go version to 1.18
  docs(user): add monitoring related user guides
  refactor(provisoining): make use of the new context api
  test(ut): handling volume deletion failures 
  test(integation): handling incorrect jiva images
  test(e2e): running nfs on jiva volumes
-->
