### PR TITLE
fix: Jiva controller service does not select controller pods

### DIFF
--- a/pkg/controllers/jivavolume_controller.go
+++ b/pkg/controllers/jivavolume_controller.go
@@ -1195,6 +1195,7 @@ func createControllerService(r *JivaVolumeReconciler, cr *jivaAPI.JivaVolume) er
 		WithNamespace(cr.Namespace).
 		WithSelectorsNew(map[string]string{
 			"openebs.io/cas-type":          "jiva",
+			"openebs.io/component":         "jiva-controller",
 			"openebs.io/persistent-volume": cr.Spec.PV,
 		}).
 		WithPorts(defaultControllerSVCPorts()).


### PR DESCRIPTION
**What this PR does?**:

This PR Ensures that the Jiva contoller service selects controller pods. Previously the controller service would select both controller pods and replicas. The resulted in most calls to the controller API failing

**Does this PR require any upgrade changes?**:

I don't think so. I assume the controller service should only point to controller pods anyway.

I have not verified this PR, but I have experienced the issue.

This is my first PR for this project, and I'm not really a Go developer. I am hoping this PR is simple enough (a single line) that a maintainer of this project can easily reason about it.