### PR TITLE
release(helm-chart): changes for helm chart 3.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v3.2.0 / 2022-04-19
+===================
+* rename 'defaultClass' helm chart template values object to 'storageClass' ([#184](https://github.com/openebs/jiva-operator/pull/184)), [@niladrih](https://github.com/niladrih))
+
 v3.1.0 / 2022-01-03
 ========================
 * feat(api): adding v1 CRDs ([#167](https://github.com/openebs/jiva-operator/pull/167),[@shubham14bajpai](https://github.com/shubham14bajpai))

--- a/changelogs/released/3.2.0/184-niladrih
+++ b/changelogs/released/3.2.0/184-niladrih
@@ -1,0 +1,1 @@
+rename 'defaultClass' helm chart template values object to 'storageClass'

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,10 +4,10 @@ description: Helm chart for OpenEBS Jiva Operator. Jiva provides highly availabl
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.1.0
+version: 3.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.1.0
+appVersion: 3.2.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/
 keywords:
@@ -23,7 +23,7 @@ sources:
 
 dependencies:
   - name: localpv-provisioner
-    version: "3.1.0"
+    version: "3.2.0"
     repository: "https://openebs.github.io/dynamic-localpv-provisioner"
     condition: openebsLocalpv.enabled
 

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -45,7 +45,7 @@ By default this chart installs additional, dependent charts:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 3.1.0 |
+| https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 3.2.0 |
 
 **Note:** Find detailed Dynamic LocalPV Provisioner Helm chart configuration options [here](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/deploy/helm/charts/README.md).
 
@@ -170,17 +170,17 @@ helm upgrade openebs-jiva openebs-jiva/jiva -n openebs \
 | defaultPolicy.enabled | bool | `true`  | Enable default jiva volume policy |
 | defaultPolicy.replicaSC | string | `"openebs-hostpath"` | StorageClass used for creating the PVC for the replica STS |
 | defaultPolicy.replicas | string | `"3"` | The desired replication factor for the jiva volumes |
-| defaultClass.name | string | `"openebs-jiva-csi-default"` | Default jiva csi StorageClass |
-| defaultClass.enabled | bool | `true`  | Enable default jiva csi StorageClass |
-| defaultClass.allowVolumeExpansion | bool | `true` | Enable volume expansion for the Volumes |
-| defaultClass.reclaimPolicy | string | `"Delete"` | Reclaim Policy for the StorageClass |
-| defaultClass.isDefaultClass | bool | `false` | Make jiva csi StorageClass as the default StorageClass |
+| storageClass.name | string | `"openebs-jiva-csi-default"` | Default jiva csi StorageClass |
+| storageClass.enabled | bool | `true`  | Enable default jiva csi StorageClass |
+| storageClass.allowVolumeExpansion | bool | `true` | Enable volume expansion for the Volumes |
+| storageClass.reclaimPolicy | string | `"Delete"` | Reclaim Policy for the StorageClass |
+| storageClass.isDefaultClass | bool | `false` | Make jiva csi StorageClass as the default StorageClass |
 | jivaOperator.annotations | object | `{}` | Jiva operator annotations |
 | jivaOperator.componentName | string | `"jiva-operator"` | Jiva operator component name |
 | jivaOperator.image.pullPolicy | string | `"IfNotPresent"` | Jiva operator image pull policy |
 | jivaOperator.image.registry | string | `nil` | Jiva operator image registry |
 | jivaOperator.image.repository | string | `"openebs/jiva-operator"` | Jiva operator image repository |
-| jivaOperator.image.tag | string | `"3.1.0"` |  Jiva operator image tag |
+| jivaOperator.image.tag | string | `"3.2.0"` |  Jiva operator image tag |
 | jivaOperator.nodeSelector | object | `{}` |  Jiva operator pod nodeSelector|
 | jivaOperator.podAnnotations | object | `{}` | Jiva operator pod annotations |
 | jivaOperator.resources | object | `{}` | Jiva operator pod resources |
@@ -189,12 +189,12 @@ helm upgrade openebs-jiva openebs-jiva/jiva -n openebs \
 | jivaCSIPlugin.image.pullPolicy | string | `"IfNotPresent"` | Jiva CSI driver image pull policy |
 | jivaCSIPlugin.image.registry | string | `nil` | Jiva CSI driver image registry |
 | jivaCSIPlugin.image.repository | string | `"openebs/jiva-csi"` |  Jiva CSI driver image repository |
-| jivaCSIPlugin.image.tag | string | `"3.1.0"` | Jiva CSI driver image tag |
+| jivaCSIPlugin.image.tag | string | `"3.2.0"` | Jiva CSI driver image tag |
 | jivaCSIPlugin.name | string | `"jiva-csi-plugin"` | Jiva CSI driver container name |
 | jivaCSIPlugin.remount | string | `"true"` | Jiva CSI driver remount feature, enabled by default |
 | rbac.create | bool | `true` | Enable RBAC |
 | rbac.pspEnabled | bool | `false` | Enable PodSecurityPolicy |
-| release.version | string | `"3.1.0"` | Openebs Jiva release version |
+| release.version | string | `"3.2.0"` | Openebs Jiva release version |
 | serviceAccount.annotations | object | `{}` | Service Account annotations |
 | serviceAccount.csiController.create | bool | `true` | Enable CSI Controller ServiceAccount |
 | serviceAccount.csiController.name | string | `"openebs-jiva-csi-controller-sa"` | CSI Controller ServiceAccount name |

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -177,12 +177,21 @@ helm upgrade openebs-jiva openebs-jiva/jiva -n openebs \
 | storageClass.isDefaultClass | bool | `false` | Make jiva csi StorageClass as the default StorageClass |
 | jivaOperator.annotations | object | `{}` | Jiva operator annotations |
 | jivaOperator.componentName | string | `"jiva-operator"` | Jiva operator component name |
+| jivaOperator.controller.image.registry | `nil` | Jiva volume controller container image registry |
+| jivaOperator.controller.image.repository | `openebs/jiva` | Jiva volume controller container image repository |
+| jivaOperator.controller.image.tag | `"3.2.0"` | Jiva volume controller container image tag |
+| jivaOperator.exporter.image.registry | `nil` | Jiva volume metrics exporter container image registry |
+| jivaOperator.exporter.image.repository | `openebs/m-exporter` | Jiva volume metrics exporter container image repository |
+| jivaOperator.exporter.image.tag | `"3.2.0"` | Jiva volume metrics exporter container image tag |
 | jivaOperator.image.pullPolicy | string | `"IfNotPresent"` | Jiva operator image pull policy |
 | jivaOperator.image.registry | string | `nil` | Jiva operator image registry |
 | jivaOperator.image.repository | string | `"openebs/jiva-operator"` | Jiva operator image repository |
 | jivaOperator.image.tag | string | `"3.2.0"` |  Jiva operator image tag |
 | jivaOperator.nodeSelector | object | `{}` |  Jiva operator pod nodeSelector|
 | jivaOperator.podAnnotations | object | `{}` | Jiva operator pod annotations |
+| jivaOperator.replica.image.registry | `nil` | Jiva volume replica container image registry |
+| jivaOperator.replica.image.repository | `openebs/jiva` | Jiva volume replica container image repository |
+| jivaOperator.replica.image.tag | `"3.2.0"` | Jiva volume replica container image tag |
 | jivaOperator.resources | object | `{}` | Jiva operator pod resources |
 | jivaOperator.securityContext | object | `{}` | Jiva operator security context |
 | jivaOperator.tolerations | list | `[]` | Jiva operator pod tolerations |

--- a/deploy/helm/charts/templates/default-storageclass.yaml
+++ b/deploy/helm/charts/templates/default-storageclass.yaml
@@ -1,16 +1,16 @@
-{{- if .Values.defaultClass.enabled }}
+{{- if .Values.storageClass.enabled }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ .Values.defaultClass.name }}
+  name: {{ .Values.storageClass.name }}
   annotations:
-{{- if .Values.defaultClass.isDefaultClass }}
+{{- if .Values.storageClass.isDefaultClass }}
     storageclass.kubernetes.io/is-default-class: "true"
 {{- end }}
 provisioner: jiva.csi.openebs.io
 volumeBindingMode: Immediate
-allowVolumeExpansion: {{ .Values.defaultClass.allowVolumeExpansion }}
-reclaimPolicy: {{ .Values.defaultClass.reclaimPolicy }}
+allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
 parameters:
   cas-type: "jiva"
   policy: {{ .Values.defaultPolicy.name }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 release:
-  version: "3.1.0"
+  version: "3.2.0"
 
 
 # If false, openebs localpv sub-chart will not be installed
@@ -25,17 +25,17 @@ jivaOperator:
     image:
       registry:
       repository: openebs/jiva
-      tag: 3.1.0
+      tag: 3.2.0
   replica:
     image:
       registry:
       repository: openebs/jiva
-      tag: 3.1.0
+      tag: 3.2.0
   exporter:
     image:
       registry:
       repository: openebs/m-exporter
-      tag: 3.1.0
+      tag: 3.2.0
   image:
     # Make sure that registry name end with a '/'.
     # For example : quay.io/ is a correct value here and quay.io is incorrect
@@ -43,7 +43,7 @@ jivaOperator:
     repository: openebs/jiva-operator
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.1.0
+    tag: 3.2.0
   annotations: {}
   resyncInterval: "30"
   podAnnotations: {}
@@ -118,7 +118,7 @@ jivaCSIPlugin:
     repository: openebs/jiva-csi
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.1.0
+    tag: 3.2.0
   remount: "true"
 
 csiNode:
@@ -187,14 +187,15 @@ serviceAccount:
     create: true
     name: openebs-jiva-csi-node-sa
 
-defaultClass:
-  # Name of the default default StorageClass
+storageClass:
+  # Name of the default StorageClass
   name: openebs-jiva-csi-default
   # If true, enables creation of the openebs-jiva-csi-default StorageClass
   enabled: true
   # Available reclaim policies: Delete/Retain, defaults: Delete.
   reclaimPolicy: Delete
-  # If true, sets the openebs-jiva-csi-default StorageClass as the default StorageClass
+  # If true, sets the openebs-jiva-csi-default StorageClass as the
+  # default kubernetes StorageClass for the cluster
   isDefaultClass: false
   # If true, allows resize of the volumes
   allowVolumeExpansion: true


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

Changes:
- Bumps Chart version, App version, and image versions to 3.2.0
- Renames 'defaultClass' values.yaml section to 'storageClass'. This is because the defaultClass makes the option isDefaultClass (embedded inside the defaultClass object) look confusing. If someone wanted to enable the annotation to use the Jiva storageClass, he might assume `--set defaultClass.enable=true` will work. But, in reality the flag only enabled the Jiva storageClass. To get the annotation, the right option is `--set defaultClass.isDefaultClass=true`. So, I've changed 'defaultClass' to 'storageClass'

This PR requires the following to be merged:
- https://github.com/openebs/dynamic-localpv-provisioner/pull/133