### PR TITLE
[cherry-pick]: Add sleep command to wait before finishing the dumping of test-data

### DIFF
--- a/e2e-tests/experiments/chaos/revision_counter/run_e2e_test.yml
+++ b/e2e-tests/experiments/chaos/revision_counter/run_e2e_test.yml
@@ -36,7 +36,7 @@ spec:
 
             # Block Size to dump the data using dd 
           - name: BLOCK_SIZE
-            value: '3000000'
+            value: '2000000'
 
             # Block Count to dump the data using dd
           - name: BLOCK_COUNT

--- a/e2e-tests/experiments/chaos/revision_counter/test.yml
+++ b/e2e-tests/experiments/chaos/revision_counter/test.yml
@@ -87,6 +87,12 @@
         - include_tasks: ./delete_jiva_csi_replica.yml
           loop: "{{ range(0, 10 | int, 1)|list }}"
 
+        - name: Sleep for some time to finish the dumping of test-data.
+          shell: >
+            sleep 720
+          args:
+            executable: /bin/bash
+
         - name: Wait until the dumping process is finished and pid was destroyed
           wait_for:
             path: /proc/{{ p_id.stdout }}/status


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
