### PR TITLE
[stable/jiva]: update jiva charts to 3.3.0 release

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,10 +4,10 @@ description: Helm chart for OpenEBS Jiva Operator. Jiva provides highly availabl
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.2.0
+version: 3.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.2.0
+appVersion: 3.3.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/
 keywords:
@@ -23,7 +23,7 @@ sources:
 
 dependencies:
   - name: localpv-provisioner
-    version: "3.2.0"
+    version: "3.3.0"
     repository: "https://openebs.github.io/dynamic-localpv-provisioner"
     condition: openebsLocalpv.enabled
 

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -45,7 +45,7 @@ By default this chart installs additional, dependent charts:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 3.2.0 |
+| https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 3.3.0   |
 
 **Note:** Find detailed Dynamic LocalPV Provisioner Helm chart configuration options [here](https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/deploy/helm/charts/README.md).
 
@@ -106,111 +106,111 @@ helm upgrade openebs-jiva openebs-jiva/jiva -n openebs \
 	--set localpv-provisioner.deviceClass.enabled=true
 ```
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| csiController.annotations | object | `{}` | CSI controller annotations |
-| csiController.attacher.image.pullPolicy | string | `"IfNotPresent"` | CSI attacher image pull policy |
-| csiController.attacher.image.registry | string | `"k8s.gcr.io/"` |  CSI attacher image registry |
-| csiController.attacher.image.repository | string | `"k8scsi/csi-attacher"` |  CSI attacher image repo |
-| csiController.attacher.image.tag | string | `"v3.1.0"` | CSI attacher image tag |
-| csiController.attacher.logLevel | string | _unspecified_ |  Override CSI attacher container log level (1 = least verbose, 5 = most verbose) |
-| csiController.attacher.name | string | `"csi-attacher"` |  CSI attacher container name|
-| csiController.componentName | string | `""` | CSI controller component name |
-| csiController.driverRegistrar.image.pullPolicy | string | `"IfNotPresent"` | CSI driver registrar image pull policy  |
-| csiController.driverRegistrar.image.registry | string | `"k8s.gcr.io/"` | CSI driver registrar image registry |
-| csiController.driverRegistrar.image.repository | string | `"k8scsi/csi-cluster-driver-registrar"` | CSI driver registrar image repo |
-| csiController.driverRegistrar.image.tag | string | `"v1.0.1"` |  CSI driver registrar image tag|
-| csiController.driverRegistrar.name | string | `"csi-cluster-driver-registrar"` | CSI driver registrar container name  |
-| csiController.livenessprobe.image.pullPolicy | string | `"IfNotPresent"` | CSI livenessprobe image pull policy |
-| csiController.livenessprobe.image.registry | string | `"k8s.gcr.io/"` |  CSI livenessprobe image registry |
-| csiController.livenessprobe.image.repository | string | `"k8scsi/livenessprobe"` |  CSI livenessprobe image repo |
-| csiController.livenessprobe.image.tag | string | `"v2.3.0"` | CSI livenessprobe image tag |
-| csiController.livenessprobe.name | string | `"liveness-probe"` |  CSI livenessprobe container name|
-| csiController.logLevel | string | `"5"` | Default log level for all CSI controller containers (1 = least verbose, 5 = most verbose) unless overridden for a specific container |
-| csiController.nodeSelector | object | `{}` |  CSI controller pod node selector |
-| csiController.podAnnotations | object | `{}` | CSI controller pod annotations |
-| csiController.provisioner.image.pullPolicy | string | `"IfNotPresent"` | CSI provisioner image pull policy |
-| csiController.provisioner.image.registry | string | `"k8s.gcr.io/"` | CSI provisioner image pull registry |
-| csiController.provisioner.image.repository | string | `"k8scsi/csi-provisioner"` | CSI provisioner image pull repository |
-| csiController.provisioner.image.tag | string | `"v3.0.0"` | CSI provisioner image tag |
-| csiController.provisioner.logLevel | string | _unspecified_ | Override CSI provisioner container log level (1 = least verbose, 5 = most verbose) |
-| csiController.provisioner.name | string | `"csi-provisioner"` | CSI provisioner container name |
-| csiController.resizer.image.pullPolicy | string | `"IfNotPresent"` | CSI resizer image pull policy  |
-| csiController.resizer.image.registry | string | `"k8s.gcr.io/"` | CSI resizer image registry |
-| csiController.resizer.image.repository | string | `"k8scsi/csi-resizer"` |  CSI resizer image repository|
-| csiController.resizer.image.tag | string | `"v1.2.0"` | CSI resizer image tag |
-| csiController.resizer.logLevel | string | _unspecified_ | Override CSI resizer container log level (1 = least verbose, 5 = most verbose) |
-| csiController.resizer.name | string | `"csi-resizer"` | CSI resizer container name |
-| csiController.resources | object | `{}` | CSI controller container resources |
-| csiController.securityContext | object | `{}` | CSI controller security context |
-| csiController.tolerations | list | `[]` | CSI controller pod tolerations |
-| csiNode.annotations | object | `{}` | CSI Node annotations |
-| csiNode.componentName | string | `"openebs-jiva-csi-node"` | CSI Node component name |
-| csiNode.driverRegistrar.image.pullPolicy | string | `"IfNotPresent"` | CSI Node driver registrar image pull policy|
-| csiNode.driverRegistrar.image.registry | string | `"k8s.gcr.io/"` | CSI Node driver registrar image registry |
-| csiNode.driverRegistrar.image.repository | string | `"k8scsi/csi-node-driver-registrar"` | CSI Node driver registrar image repository |
-| csiNode.driverRegistrar.image.tag | string | `"v2.3.0"` |  CSI Node driver registrar image tag|
-| csiNode.driverRegistrar.name | string | `"csi-node-driver-registrar"` | CSI Node driver registrar container name |
-| csiNode.driverRegistrar.logLevel | string | _unspecified_ | Override CSI node driver registrar container log level (1 = least verbose, 5 = most verbose) |
-| csiNode.kubeletDir | string | `"/var/lib/kubelet/"` | Kubelet root dir |
-| csiNode.labels | object | `{}` | CSI Node pod labels |
-| csiNode.logLevel | string | `"5"` | Default log level for all CSI node pod containers (1 = least verbose, 5 = most verbose) unless overridden for a specific container |
-| csiNode.nodeSelector | object | `{}` |   CSI Node pod nodeSelector |
-| csiNode.podAnnotations | object | `{}` | CSI Node pod annotations |
-| csiNode.resources | object | `{}` | CSI Node pod resources |
-| csiNode.securityContext | object | `{}` | CSI Node pod security context |
-| csiNode.tolerations | list | `[]` | CSI Node pod tolerations |
-| csiNode.updateStrategy.type | string | `"RollingUpdate"` | CSI Node daemonset update strategy |
-| csiNode.livenessprobe.image.pullPolicy | string | `"IfNotPresent"` | CSI livenessprobe image pull policy |
-| csiNode.livenessprobe.image.registry | string | `"k8s.gcr.io/"` |  CSI livenessprobe image registry |
-| csiNode.livenessprobe.image.repository | string | `"k8scsi/livenessprobe"` |  CSI livenessprobe image repo |
-| csiNode.livenessprobe.image.tag | string | `"v2.3.0"` | CSI livenessprobe image tag |
-| csiNode.livenessprobe.name | string | `"liveness-probe"` |  CSI livenessprobe container name|
-| defaultPolicy.name | string | `"openebs-jiva-default-policy"` | Default jiva volume policy |
-| defaultPolicy.enabled | bool | `true`  | Enable default jiva volume policy |
-| defaultPolicy.replicaSC | string | `"openebs-hostpath"` | StorageClass used for creating the PVC for the replica STS |
-| defaultPolicy.replicas | string | `"3"` | The desired replication factor for the jiva volumes |
-| storageClass.name | string | `"openebs-jiva-csi-default"` | Default jiva csi StorageClass |
-| storageClass.enabled | bool | `true`  | Enable default jiva csi StorageClass |
-| storageClass.allowVolumeExpansion | bool | `true` | Enable volume expansion for the Volumes |
-| storageClass.reclaimPolicy | string | `"Delete"` | Reclaim Policy for the StorageClass |
-| storageClass.isDefaultClass | bool | `false` | Make jiva csi StorageClass as the default StorageClass |
-| jivaOperator.annotations | object | `{}` | Jiva operator annotations |
-| jivaOperator.componentName | string | `"jiva-operator"` | Jiva operator component name |
-| jivaOperator.controller.image.registry | `nil` | Jiva volume controller container image registry |
-| jivaOperator.controller.image.repository | `openebs/jiva` | Jiva volume controller container image repository |
-| jivaOperator.controller.image.tag | `"3.2.0"` | Jiva volume controller container image tag |
-| jivaOperator.exporter.image.registry | `nil` | Jiva volume metrics exporter container image registry |
+| Key | Type                 | Default                                                 | Description |
+|-----|----------------------|---------------------------------------------------------|-------------|
+| csiController.annotations | object               | `{}`                                                    | CSI controller annotations |
+| csiController.attacher.image.pullPolicy | string               | `"IfNotPresent"`                                        | CSI attacher image pull policy |
+| csiController.attacher.image.registry | string               | `"k8s.gcr.io/"`                                         |  CSI attacher image registry |
+| csiController.attacher.image.repository | string               | `"k8scsi/csi-attacher"`                                 |  CSI attacher image repo |
+| csiController.attacher.image.tag | string               | `"v3.1.0"`                                              | CSI attacher image tag |
+| csiController.attacher.logLevel | string               | _unspecified_                                           |  Override CSI attacher container log level (1 = least verbose, 5 = most verbose) |
+| csiController.attacher.name | string               | `"csi-attacher"`                                        |  CSI attacher container name|
+| csiController.componentName | string               | `""`                                                    | CSI controller component name |
+| csiController.driverRegistrar.image.pullPolicy | string               | `"IfNotPresent"`                                        | CSI driver registrar image pull policy  |
+| csiController.driverRegistrar.image.registry | string               | `"k8s.gcr.io/"`                                         | CSI driver registrar image registry |
+| csiController.driverRegistrar.image.repository | string               | `"k8scsi/csi-cluster-driver-registrar"`                 | CSI driver registrar image repo |
+| csiController.driverRegistrar.image.tag | string               | `"v1.0.1"`                                              |  CSI driver registrar image tag|
+| csiController.driverRegistrar.name | string               | `"csi-cluster-driver-registrar"`                        | CSI driver registrar container name  |
+| csiController.livenessprobe.image.pullPolicy | string               | `"IfNotPresent"`                                        | CSI livenessprobe image pull policy |
+| csiController.livenessprobe.image.registry | string               | `"k8s.gcr.io/"`                                         |  CSI livenessprobe image registry |
+| csiController.livenessprobe.image.repository | string               | `"k8scsi/livenessprobe"`                                |  CSI livenessprobe image repo |
+| csiController.livenessprobe.image.tag | string               | `"v2.3.0"`                                              | CSI livenessprobe image tag |
+| csiController.livenessprobe.name | string               | `"liveness-probe"`                                      |  CSI livenessprobe container name|
+| csiController.logLevel | string               | `"5"`                                                   | Default log level for all CSI controller containers (1 = least verbose, 5 = most verbose) unless overridden for a specific container |
+| csiController.nodeSelector | object               | `{}`                                                    |  CSI controller pod node selector |
+| csiController.podAnnotations | object               | `{}`                                                    | CSI controller pod annotations |
+| csiController.provisioner.image.pullPolicy | string               | `"IfNotPresent"`                                        | CSI provisioner image pull policy |
+| csiController.provisioner.image.registry | string               | `"k8s.gcr.io/"`                                         | CSI provisioner image pull registry |
+| csiController.provisioner.image.repository | string               | `"k8scsi/csi-provisioner"`                              | CSI provisioner image pull repository |
+| csiController.provisioner.image.tag | string               | `"v3.0.0"`                                              | CSI provisioner image tag |
+| csiController.provisioner.logLevel | string               | _unspecified_                                           | Override CSI provisioner container log level (1 = least verbose, 5 = most verbose) |
+| csiController.provisioner.name | string               | `"csi-provisioner"`                                     | CSI provisioner container name |
+| csiController.resizer.image.pullPolicy | string               | `"IfNotPresent"`                                        | CSI resizer image pull policy  |
+| csiController.resizer.image.registry | string               | `"k8s.gcr.io/"`                                         | CSI resizer image registry |
+| csiController.resizer.image.repository | string               | `"k8scsi/csi-resizer"`                                  |  CSI resizer image repository|
+| csiController.resizer.image.tag | string               | `"v1.2.0"`                                              | CSI resizer image tag |
+| csiController.resizer.logLevel | string               | _unspecified_                                           | Override CSI resizer container log level (1 = least verbose, 5 = most verbose) |
+| csiController.resizer.name | string               | `"csi-resizer"`                                         | CSI resizer container name |
+| csiController.resources | object               | `{}`                                                    | CSI controller container resources |
+| csiController.securityContext | object               | `{}`                                                    | CSI controller security context |
+| csiController.tolerations | list                 | `[]`                                                    | CSI controller pod tolerations |
+| csiNode.annotations | object               | `{}`                                                    | CSI Node annotations |
+| csiNode.componentName | string               | `"openebs-jiva-csi-node"`                               | CSI Node component name |
+| csiNode.driverRegistrar.image.pullPolicy | string               | `"IfNotPresent"`                                        | CSI Node driver registrar image pull policy|
+| csiNode.driverRegistrar.image.registry | string               | `"k8s.gcr.io/"`                                         | CSI Node driver registrar image registry |
+| csiNode.driverRegistrar.image.repository | string               | `"k8scsi/csi-node-driver-registrar"`                    | CSI Node driver registrar image repository |
+| csiNode.driverRegistrar.image.tag | string               | `"v2.3.0"`                                              |  CSI Node driver registrar image tag|
+| csiNode.driverRegistrar.name | string               | `"csi-node-driver-registrar"`                           | CSI Node driver registrar container name |
+| csiNode.driverRegistrar.logLevel | string               | _unspecified_                                           | Override CSI node driver registrar container log level (1 = least verbose, 5 = most verbose) |
+| csiNode.kubeletDir | string               | `"/var/lib/kubelet/"`                                   | Kubelet root dir |
+| csiNode.labels | object               | `{}`                                                    | CSI Node pod labels |
+| csiNode.logLevel | string               | `"5"`                                                   | Default log level for all CSI node pod containers (1 = least verbose, 5 = most verbose) unless overridden for a specific container |
+| csiNode.nodeSelector | object               | `{}`                                                    |   CSI Node pod nodeSelector |
+| csiNode.podAnnotations | object               | `{}`                                                    | CSI Node pod annotations |
+| csiNode.resources | object               | `{}`                                                    | CSI Node pod resources |
+| csiNode.securityContext | object               | `{}`                                                    | CSI Node pod security context |
+| csiNode.tolerations | list                 | `[]`                                                    | CSI Node pod tolerations |
+| csiNode.updateStrategy.type | string               | `"RollingUpdate"`                                       | CSI Node daemonset update strategy |
+| csiNode.livenessprobe.image.pullPolicy | string               | `"IfNotPresent"`                                        | CSI livenessprobe image pull policy |
+| csiNode.livenessprobe.image.registry | string               | `"k8s.gcr.io/"`                                         |  CSI livenessprobe image registry |
+| csiNode.livenessprobe.image.repository | string               | `"k8scsi/livenessprobe"`                                |  CSI livenessprobe image repo |
+| csiNode.livenessprobe.image.tag | string               | `"v2.3.0"`                                              | CSI livenessprobe image tag |
+| csiNode.livenessprobe.name | string               | `"liveness-probe"`                                      |  CSI livenessprobe container name|
+| defaultPolicy.name | string               | `"openebs-jiva-default-policy"`                         | Default jiva volume policy |
+| defaultPolicy.enabled | bool                 | `true`                                                  | Enable default jiva volume policy |
+| defaultPolicy.replicaSC | string               | `"openebs-hostpath"`                                    | StorageClass used for creating the PVC for the replica STS |
+| defaultPolicy.replicas | string               | `"3"`                                                   | The desired replication factor for the jiva volumes |
+| storageClass.name | string               | `"openebs-jiva-csi-default"`                            | Default jiva csi StorageClass |
+| storageClass.enabled | bool                 | `true`                                                  | Enable default jiva csi StorageClass |
+| storageClass.allowVolumeExpansion | bool                 | `true`                                                  | Enable volume expansion for the Volumes |
+| storageClass.reclaimPolicy | string               | `"Delete"`                                              | Reclaim Policy for the StorageClass |
+| storageClass.isDefaultClass | bool                 | `false`                                                 | Make jiva csi StorageClass as the default StorageClass |
+| jivaOperator.annotations | object               | `{}`                                                    | Jiva operator annotations |
+| jivaOperator.componentName | string               | `"jiva-operator"`                                       | Jiva operator component name |
+| jivaOperator.controller.image.registry | `nil`                | Jiva volume controller container image registry         |
+| jivaOperator.controller.image.repository | `openebs/jiva`       | Jiva volume controller container image repository       |
+| jivaOperator.controller.image.tag | `"3.3.0"`            | Jiva volume controller container image tag              |
+| jivaOperator.exporter.image.registry | `nil`                | Jiva volume metrics exporter container image registry   |
 | jivaOperator.exporter.image.repository | `openebs/m-exporter` | Jiva volume metrics exporter container image repository |
-| jivaOperator.exporter.image.tag | `"3.2.0"` | Jiva volume metrics exporter container image tag |
-| jivaOperator.image.pullPolicy | string | `"IfNotPresent"` | Jiva operator image pull policy |
-| jivaOperator.image.registry | string | `nil` | Jiva operator image registry |
-| jivaOperator.image.repository | string | `"openebs/jiva-operator"` | Jiva operator image repository |
-| jivaOperator.image.tag | string | `"3.2.0"` |  Jiva operator image tag |
-| jivaOperator.nodeSelector | object | `{}` |  Jiva operator pod nodeSelector|
-| jivaOperator.podAnnotations | object | `{}` | Jiva operator pod annotations |
-| jivaOperator.replica.image.registry | `nil` | Jiva volume replica container image registry |
-| jivaOperator.replica.image.repository | `openebs/jiva` | Jiva volume replica container image repository |
-| jivaOperator.replica.image.tag | `"3.2.0"` | Jiva volume replica container image tag |
-| jivaOperator.resources | object | `{}` | Jiva operator pod resources |
-| jivaOperator.securityContext | object | `{}` | Jiva operator security context |
-| jivaOperator.tolerations | list | `[]` | Jiva operator pod tolerations |
-| jivaCSIPlugin.image.pullPolicy | string | `"IfNotPresent"` | Jiva CSI driver image pull policy |
-| jivaCSIPlugin.image.registry | string | `nil` | Jiva CSI driver image registry |
-| jivaCSIPlugin.image.repository | string | `"openebs/jiva-csi"` |  Jiva CSI driver image repository |
-| jivaCSIPlugin.image.tag | string | `"3.2.0"` | Jiva CSI driver image tag |
-| jivaCSIPlugin.name | string | `"jiva-csi-plugin"` | Jiva CSI driver container name |
-| jivaCSIPlugin.remount | string | `"true"` | Jiva CSI driver remount feature, enabled by default |
-| rbac.create | bool | `true` | Enable RBAC |
-| rbac.pspEnabled | bool | `false` | Enable PodSecurityPolicy |
-| release.version | string | `"3.2.0"` | Openebs Jiva release version |
-| serviceAccount.annotations | object | `{}` | Service Account annotations |
-| serviceAccount.csiController.create | bool | `true` | Enable CSI Controller ServiceAccount |
-| serviceAccount.csiController.name | string | `"openebs-jiva-csi-controller-sa"` | CSI Controller ServiceAccount name |
-| serviceAccount.csiNode.create | bool | `true` | Enable CSI Node ServiceAccount |
-| serviceAccount.csiNode.name | string | `"openebs-jiva-csi-node-sa"` | CSI Node ServiceAccount name |
-| serviceAccount.jivaOperator.create | bool | `true` | Enable Jiva Operator Node ServiceAccount |
-| serviceAccount.jivaOperator.name | string | `"openebs-jiva-operator"` | Jiva Operator ServiceAccount name |
+| jivaOperator.exporter.image.tag | `"3.3.0"`            | Jiva volume metrics exporter container image tag        |
+| jivaOperator.image.pullPolicy | string               | `"IfNotPresent"`                                        | Jiva operator image pull policy |
+| jivaOperator.image.registry | string               | `nil`                                                   | Jiva operator image registry |
+| jivaOperator.image.repository | string               | `"openebs/jiva-operator"`                               | Jiva operator image repository |
+| jivaOperator.image.tag | string               | `"3.3.0"`                                               |  Jiva operator image tag |
+| jivaOperator.nodeSelector | object               | `{}`                                                    |  Jiva operator pod nodeSelector|
+| jivaOperator.podAnnotations | object               | `{}`                                                    | Jiva operator pod annotations |
+| jivaOperator.replica.image.registry | `nil`                | Jiva volume replica container image registry            |
+| jivaOperator.replica.image.repository | `openebs/jiva`       | Jiva volume replica container image repository          |
+| jivaOperator.replica.image.tag | `"3.3.0"`            | Jiva volume replica container image tag                 |
+| jivaOperator.resources | object               | `{}`                                                    | Jiva operator pod resources |
+| jivaOperator.securityContext | object               | `{}`                                                    | Jiva operator security context |
+| jivaOperator.tolerations | list                 | `[]`                                                    | Jiva operator pod tolerations |
+| jivaCSIPlugin.image.pullPolicy | string               | `"IfNotPresent"`                                        | Jiva CSI driver image pull policy |
+| jivaCSIPlugin.image.registry | string               | `nil`                                                   | Jiva CSI driver image registry |
+| jivaCSIPlugin.image.repository | string               | `"openebs/jiva-csi"`                                    |  Jiva CSI driver image repository |
+| jivaCSIPlugin.image.tag | string               | `"3.3.0"`                                               | Jiva CSI driver image tag |
+| jivaCSIPlugin.name | string               | `"jiva-csi-plugin"`                                     | Jiva CSI driver container name |
+| jivaCSIPlugin.remount | string               | `"true"`                                                | Jiva CSI driver remount feature, enabled by default |
+| rbac.create | bool                 | `true`                                                  | Enable RBAC |
+| rbac.pspEnabled | bool                 | `false`                                                 | Enable PodSecurityPolicy |
+| release.version | string               | `"3.3.0"`                                               | Openebs Jiva release version |
+| serviceAccount.annotations | object               | `{}`                                                    | Service Account annotations |
+| serviceAccount.csiController.create | bool                 | `true`                                                  | Enable CSI Controller ServiceAccount |
+| serviceAccount.csiController.name | string               | `"openebs-jiva-csi-controller-sa"`                      | CSI Controller ServiceAccount name |
+| serviceAccount.csiNode.create | bool                 | `true`                                                  | Enable CSI Node ServiceAccount |
+| serviceAccount.csiNode.name | string               | `"openebs-jiva-csi-node-sa"`                            | CSI Node ServiceAccount name |
+| serviceAccount.jivaOperator.create | bool                 | `true`                                                  | Enable Jiva Operator Node ServiceAccount |
+| serviceAccount.jivaOperator.name | string               | `"openebs-jiva-operator"`                               | Jiva Operator ServiceAccount name |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/deploy/helm/charts/templates/csi-controller.yaml
+++ b/deploy/helm/charts/templates/csi-controller.yaml
@@ -118,7 +118,7 @@ spec:
           emptyDir: {}
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 2 }}
+{{ toYaml .Values.imagePullSecrets | nindent 8 }}
 {{- end }}
 {{- if .Values.csiController.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/charts/templates/csi-node.yaml
+++ b/deploy/helm/charts/templates/csi-node.yaml
@@ -149,7 +149,7 @@ spec:
             type: Directory
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 2 }}
+{{ toYaml .Values.imagePullSecrets | nindent 8 }}
 {{- end }}
 {{- if .Values.csiNode.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/charts/templates/jiva-operator.yaml
+++ b/deploy/helm/charts/templates/jiva-operator.yaml
@@ -58,7 +58,7 @@ spec:
 {{- end }}
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 2 }}
+{{ toYaml .Values.imagePullSecrets | nindent 8 }}
 {{- end }}
 {{- if .Values.jivaOperator.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 release:
-  version: "3.2.0"
+  version: "3.3.0"
 
 
 # If false, openebs localpv sub-chart will not be installed
@@ -25,17 +25,17 @@ jivaOperator:
     image:
       registry:
       repository: openebs/jiva
-      tag: 3.2.0
+      tag: 3.3.0
   replica:
     image:
       registry:
       repository: openebs/jiva
-      tag: 3.2.0
+      tag: 3.3.0
   exporter:
     image:
       registry:
       repository: openebs/m-exporter
-      tag: 3.2.0
+      tag: 3.3.0
   image:
     # Make sure that registry name end with a '/'.
     # For example : quay.io/ is a correct value here and quay.io is incorrect
@@ -43,7 +43,7 @@ jivaOperator:
     repository: openebs/jiva-operator
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.2.0
+    tag: 3.3.0
   annotations: {}
   resyncInterval: "30"
   podAnnotations: {}
@@ -118,7 +118,7 @@ jivaCSIPlugin:
     repository: openebs/jiva-csi
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.2.0
+    tag: 3.3.0
   remount: "true"
 
 csiNode:


### PR DESCRIPTION
This PR does the following changes:
Updates jiva charts to use new 3.3.0 release.

Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>
