### PR TITLE
fix(BDD-tests): fix resize test validation

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -207,8 +207,8 @@ func verifyIncreasedSizeInAppPod(deployName string) {
 		if err != nil {
 			return fmt.Errorf("failed to convert volume size string. stdout: %s, err: %v", stdout, err)
 		}
-		if volSize != 10255636 {
-			return fmt.Errorf("failed to match volume size. actual: %d, expected: %d", volSize, 10255636)
+		if volSize != 10232668 {
+			return fmt.Errorf("failed to match volume size. actual: %d, expected: %d", volSize, 10232668)
 		}
 		return nil
 	}, timeout).Should(Succeed())


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder26@gmail.com>

The BDD tests keep failing for the test "[csi] [jiva] TEST VOLUME RESIZE".
https://github.com/openebs/jiva-operator/actions/runs/3146480845
This PR changes the validation criteria for successful a resize to checking if the capacity in KB says 10232668 instead of 10255636.

